### PR TITLE
fix: pad function hashes to always be 8 characters

### DIFF
--- a/mythril/laser/ethereum/svm.py
+++ b/mythril/laser/ethereum/svm.py
@@ -264,7 +264,7 @@ class LaserEVM:
                     if func_hash in (-1, -2):
                         func_hashes[itr] = func_hash
                     else:
-                        func_hashes[itr] = bytes.fromhex(hex(func_hash)[2:])
+                        func_hashes[itr] = bytes.fromhex(hex(func_hash)[2:].zfill(8))
 
             for hook in self._start_sym_trans_hooks:
                 hook()


### PR DESCRIPTION
## Why it's needed
Currenty, when specifying a transaction sequence containing a function hash with leading zeros, eg: `--transaction-sequence '[[0x0651cb35]]'` these leading zeros are dropped because of conversion to and from strings etc.. This causes the call to bytes.fromhex to fail and causes Mythril to crash.

## What I did
Add leading zeros to function hashes so that a function hash is always 8 characters. This allows function hashes with leading zeros to be used.