### PR TITLE
Arm64 Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/.*
+/build
+/docker-bake.hcl
+/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,140 @@
-FROM ubuntu:focal
+# syntax=docker/dockerfile:1
+ARG PYTHON_VERSION=3.10
+ARG INSTALLED_SOLC_VERSIONS
 
-ARG DEBIAN_FRONTEND=noninteractive
 
-# Space-separated version string without leading 'v' (e.g. "0.4.21 0.4.22") 
-ARG SOLC
+FROM python:${PYTHON_VERSION:?} AS python-wheel
+WORKDIR /wheels
 
-RUN apt-get update \
-  && apt-get install -y \
-     libsqlite3-0 \
-     libsqlite3-dev \
-  && apt-get install -y \
-     apt-utils \
-     build-essential \
-     locales \
-     python-pip-whl \
-     python3-pip \
-     python3-setuptools \
-     software-properties-common \
-  && add-apt-repository -y ppa:ethereum/ethereum \
-  && apt-get update \
-  && apt-get install -y \
-     solc \
-     libssl-dev \
-     python3-dev \
-     pandoc \
-     git \
-     wget \
-  && ln -s /usr/bin/python3 /usr/local/bin/python
 
-COPY ./requirements.txt /opt/mythril/requirements.txt
+FROM python-wheel AS python-wheel-with-cargo
+# Enable cargo sparse-registry to prevent it using large amounts of memory in
+# docker builds, and speed up builds by downloading less.
+# https://github.com/rust-lang/cargo/issues/10781#issuecomment-1163819998
+ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
 
-RUN cd /opt/mythril \
-  && pip3 install -r requirements.txt
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH=/root/.cargo/bin:$PATH
 
-RUN locale-gen en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.en
-ENV LC_ALL en_US.UTF-8
 
-COPY . /opt/mythril
-RUN cd /opt/mythril \
-  && python setup.py install
+# z3-solver needs to build from src on arm, and it takes a long time, so
+# building it in a separate stage helps parallelise the build and helps it stay
+# in the build cache.
+FROM python-wheel AS python-wheel-z3-solver
+RUN --mount=source=requirements.txt,target=/run/requirements.txt \
+  pip wheel "$(grep z3-solver /run/requirements.txt)"
 
+
+FROM python-wheel-with-cargo AS python-wheel-blake2b
+# blake2b-py doesn't publish ARM builds, and also don't publish source packages
+# on PyPI (other than the old 0.1.3 version) so we need to build from from a git
+# tag. They do publish binaries for linux amd64, but their binaries only support
+# certain platform versions and the amd64 python image isn't supported, so we
+# have to build from src for that as well.
+
+# Try to get a binary build or a source release on PyPI first, then fall back
+# to building from the git repo.
+RUN pip wheel 'blake2b-py>=0.2.0,<1' \
+  || pip wheel git+https://github.com/ethereum/blake2b-py.git@v0.2.0
+
+
+FROM python-wheel AS mythril-wheels
+# cython is needed to build some wheels, such as cytoolz
+RUN pip install cython
+RUN --mount=source=requirements.txt,target=/run/requirements.txt \
+  # ignore blake2b and z3-solver as we've already built them
+  grep -v -e blake2b -e z3-solver /run/requirements.txt > /tmp/requirements-remaining.txt
+RUN pip wheel -r /tmp/requirements-remaining.txt
+
+COPY . /mythril
+RUN pip wheel --no-deps /mythril
+
+COPY --from=python-wheel-blake2b /wheels/blake2b* /wheels
+COPY --from=python-wheel-z3-solver /wheels/z3_solver* /wheels
+
+
+# Solidity Compiler Version Manager. This provides cross-platform solc builds.
+# It's used by foundry to provide solc. https://github.com/roynalnaruto/svm-rs
+FROM python-wheel-with-cargo AS solidity-compiler-version-manager
+RUN cargo install svm-rs
+# put the binaries somewhere obvious for later stages to use
+RUN mkdir -p /svm-rs/bin && cd ~/.cargo/bin/ && cp svm solc /svm-rs/bin/
+
+
+FROM python:${PYTHON_VERSION:?}-slim AS myth
+ARG PYTHON_VERSION
+# Space-separated version string without leading 'v' (e.g. "0.4.21 0.4.22")
+ARG INSTALLED_SOLC_VERSIONS
+
+COPY --from=solidity-compiler-version-manager /svm-rs/bin/* /usr/local/bin/
+
+RUN --mount=from=mythril-wheels,source=/wheels,target=/wheels \
+  export PYTHONDONTWRITEBYTECODE=1 \
+  && find /wheels -name '*.whl' -not -name "z3_solver-*-manylinux1_$(uname -m).whl" \
+    -exec pip install --no-cache-dir --no-deps {} + \
+  # z3-solver builds a wheel tagged with platform manylinux1, which pip does not
+  # report supporting, so it refuses to install it, despite it being built for
+  # this platform. Work around by overriding the platform to manylinux1
+  && find /wheels -name "z3_solver-*-manylinux1_$(uname -m).whl" \
+    -exec pip install --no-cache-dir --no-deps \
+    --target "/usr/local/lib/python${PYTHON_VERSION:?}/site-packages" \
+    --platform "manylinux1_$(uname -m)" {} \;
+
+RUN adduser --disabled-password mythril
+USER mythril
 WORKDIR /home/mythril
 
-RUN ( [ ! -z "${SOLC}" ] && set -e && for ver in $SOLC; do python -m solc.install v${ver}; done ) || true
+# pre-install solc versions
+RUN set -x; [ -z "${INSTALLED_SOLC_VERSIONS}" ] || svm install ${INSTALLED_SOLC_VERSIONS}
 
-COPY ./mythril/support/assets/signatures.db /home/mythril/.mythril/signatures.db
+COPY --chown=mythril:mythril \
+  ./mythril/support/assets/signatures.db \
+  /home/mythril/.mythril/signatures.db
 
-ENTRYPOINT ["/usr/local/bin/myth"]
+COPY --chown=root:root --chmod=755 ./docker/docker-entrypoint.sh /
+COPY --chown=root:root --chmod=755 \
+  ./docker/sync-svm-solc-versions-with-solcx.sh \
+  /usr/local/bin/sync-svm-solc-versions-with-solcx
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+
+# Basic sanity checks to make sure the build is functional
+FROM myth AS myth-smoke-test-execution
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+WORKDIR /smoke-test
+COPY --chmod=755 <<"EOT" /smoke-test.sh
+#!/usr/bin/env bash
+set -x -euo pipefail
+
+# Check solcx knows about svm solc versions
+svm install 0.5.0
+sync-svm-solc-versions-with-solcx
+python -c '
+import solcx
+print("\n".join(str(v) for v in solcx.get_installed_solc_versions()))
+' | grep -P '^0\.5\.0$' || {
+  echo "solcx did not report svm-installed solc version";
+  exit 1
+}
+
+# Check myth can run
+myth version
+myth function-to-hash 'function transfer(address _to, uint256 _value) public returns (bool success)'
+myth analyze /solidity_examples/timelock.sol > timelock.log || true
+grep 'SWC ID: 116' timelock.log || {
+  error "Failed to detect SWC ID: 116 in timelock.sol";
+  exit 1
+}
+
+# Check that the entrypoint works
+[[ $(/docker-entrypoint.sh version) == $(myth version) ]]
+[[ $(/docker-entrypoint.sh echo hi) == hi ]]
+[[ $(/docker-entrypoint.sh bash -c "printf '>%s<' 'foo bar'") == ">foo bar<" ]]
+EOT
+
+RUN --mount=source=./solidity_examples,target=/solidity_examples \
+  /smoke-test.sh 2>&1 | tee smoke-test.log
+
+
+FROM scratch as myth-smoke-test
+COPY --from=myth-smoke-test-execution /smoke-test/* /

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,52 @@
+variable "REGISTRY" {
+  default = "docker.io"
+}
+
+variable "VERSION" {
+  default = "dev"
+}
+
+variable "PYTHON_VERSION" {
+  default = "3.10"
+}
+
+variable "INSTALLED_SOLC_VERSIONS" {
+  default = "0.8.19"
+}
+
+function "myth-tags" {
+  params = [NAME]
+  result = formatlist("${REGISTRY}/${NAME}:%s", split(",", VERSION))
+}
+
+group "default" {
+  targets = ["myth", "myth-smoke-test"]
+}
+
+target "_myth-base" {
+  target = "myth"
+  args = {
+    PYTHON_VERSION = PYTHON_VERSION
+    INSTALLED_SOLC_VERSIONS = INSTALLED_SOLC_VERSIONS
+  }
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}
+
+target "myth" {
+  inherits = ["_myth-base"]
+  tags = myth-tags("mythril/myth")
+}
+
+target "myth-dev" {
+  inherits = ["_myth-base"]
+  tags = myth-tags("mythril/myth-dev")
+}
+
+target "myth-smoke-test" {
+  inherits = ["_myth-base"]
+  target = "myth-smoke-test"
+  output = ["build/docker/smoke-test"]
+}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install extra solc versions if SOLC is set
+if [[ ${SOLC:-} != "" ]]; then
+    read -ra solc_versions <<<"${SOLC:?}"
+    svm install "${solc_versions[@]}"
+fi
+# Always sync versions, as the should be at least one solc version installed
+# in the base image, and we may be running as root rather than the mythril user.
+sync-svm-solc-versions-with-solcx
+
+# By default we run myth with options from arguments we received. But if the
+# first argument is a valid program, we execute that instead so that people can
+# run other commands without overriding the entrypoint (e.g. bash).
+if command -v "${1:-}" > /dev/null; then
+    exec -- "$@"
+fi
+exec -- myth "$@"

--- a/docker/sync-svm-solc-versions-with-solcx.sh
+++ b/docker/sync-svm-solc-versions-with-solcx.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Let solcx know about the solc versions installed by svm.
+# We do this by symlinking svm's solc binaries into solcx's solc dir.
+[[ -e ~/.svm ]] || exit 0
+mkdir -p ~/.solcx
+readarray -t svm_solc_bins <<<"$(find ~/.svm -type f -name 'solc-*')"
+[[ ${svm_solc_bins[0]} != "" ]] || exit 0
+for svm_solc in "${svm_solc_bins[@]}"; do
+    name=$(basename "${svm_solc:?}")
+    version="${name#"solc-"}" # strip solc- prefix
+    solcx_solc=~/.solcx/"solc-v${version:?}"
+    if [[ ! -e $solcx_solc ]]; then
+        ln -s "${svm_solc:?}" "${solcx_solc:?}"
+    fi
+done


### PR DESCRIPTION
This resolves #1517.

I was trying to use mythril in a vscode devcontainer environment on an ARM Mac. It turned out to be quite a challenge to install mythril because many of your dependencies don't provide arm64 binaries, and some don't publish recent source releases to build from (blake2b).

I also found that your Docker image is only built for amd64, so I tried to build it on arm64 locally, and found it couldn't build for arm64. So set about adjusting the image so that I could use it. Now that I've got a working arm64 image, I figured I should offer the changes back. Hopefully it might make life easier for other people on ARM systems!

I've configured the build with a Docker Buildx bake file, so you can build the mythril/myth image for amd64 and arm64 simultaneously like this:

```console
$ docker buildx bake
```
When you're not doing a CI build, it probably makes more sense to just build the image for your platform, which you can do like this:

```console
$ docker buildx bake --set='*.platform=linux/arm64'
# or
$ docker buildx bake --set='*.platform=linux/amd64'
```
 
 (Also, running with `--print` is useful to understand what bake is going to do, it'll print out the configuration that would be built without actually building.)

The image should be functionally the same as the previous version, but there are a few changes.

- The base image is now python:3.10-slim rather than ubuntu:focal.
- It's smaller now, ~400M arm64 / 500M amd64 vs 1.3G before. This is partly because the base image is a lot smaller, and partly because it's now a multi-stage build that builds wheels in separate stages and copies them into the final stage, so there aren't any dev dependencies/files in the image now.
- It uses svm to download solc versions, both at image build time and in the image entrypoint. This is because the solcx Python package doesn't provide arm64 solc binaries. svm does, and it's also used by foundry.

  This doesn't seem ideal, but hopefully it's a reasonable starting point.
- The image runs as the mythril user rather than root by default. It can still be run as root using the `--user` docker option. This has the potential surface file permission problems for users bind-mounting directories into a myth container that aren't readable by uid 1000.

I also updated `docker_build_and_deploy.sh` to build & publish using `buildx bake`, as shown above. It's possible that your circleci environment will need a tweak. I don't use circleci myself, but they seem to support Docker Buildx: https://support.circleci.com/hc/en-us/articles/360058095471-How-To-Use-Docker-Buildx-in-Remote-Docker-

