### PR TITLE
Fix bug in resolving log message of user assertion

### DIFF
--- a/mythril/analysis/module/modules/user_assertions.py
+++ b/mythril/analysis/module/modules/user_assertions.py
@@ -76,7 +76,7 @@ class UserAssertions(DetectionModule):
                                 mem_start.value + 32 : mem_start.value + size.value
                             ]
                         ),
-                    ).decode("utf8")
+                    )
                 except:
                     pass
         try:


### PR DESCRIPTION
https://github.com/Consensys/mythril/blob/ca2dc138f856643784fa245ad29e02788f8cea2f/mythril/analysis/module/modules/user_assertions.py#L71-L81

The function `decode_single()` at L72 resolves log messages of user assertions. However, referring to [the release notes of eth_abi](https://eth-abi.readthedocs.io/en/stable/release_notes.html#v2-0-0-alpha-1), the function will return a python `str` instead of `bytes` if called with ABI type "string" since v2.0.0-alpha.1. Thus, the function will always fail silently as all exceptions will be catched by the `except` statement at L80.