### PR TITLE
Fix parsing of compiler version and reformat file

### DIFF
--- a/mythril/ethereum/util.py
+++ b/mythril/ethereum/util.py
@@ -148,7 +148,7 @@ def parse_pragma(solidity_code):
     gtr = Word(">")
     eq = Word("=")
     carrot = Word("^")
-    version = Regex(r"\s*[0-9]+\s*\.\s*[0-9]+\s*\.\s*[0-9]+")
+    version = Regex(r"\s*[0-9]+\s*\.\s*[0-9]+\s*(\.\s*[0-9]+)?")
     inequality = Optional(
         eq | (Combine(gtr + Optional(eq)) | Combine(lt + Optional(eq)))
     )

--- a/tests/integration_tests/version_test.py
+++ b/tests/integration_tests/version_test.py
@@ -14,6 +14,7 @@ test_data = (
     ("version_chaos.sol", None, True),
     ("version_2.sol", None, True),
     ("version_3.sol", None, True),
+    ("version_patch.sol", None, False),
 )
 
 

--- a/tests/testdata/input_contracts/version_patch.sol
+++ b/tests/testdata/input_contracts/version_patch.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8; // Patch version - X.y[.z] is missing
+
+contract EtherWallet {
+    address payable public owner;
+
+    constructor() {
+        owner = payable(msg.sender);
+    }
+
+    receive() external payable {}
+
+    function withdraw(uint256 _amount) external {
+        require(msg.sender == owner, "caller is not owner");
+        payable(msg.sender).transfer(_amount);
+    }
+
+    function getBalance() external view returns (uint256) {
+        return address(this).balance;
+    }
+}


### PR DESCRIPTION
Fixes a parsing error when the solidity source code specifies a version up to only the minor version number + reformatted the file with `black`:

```solidity
pragma solidity ^0.8;

contract MyContract {
....
```
Error:
```bash
mythril.interfaces.cli [ERROR]: Traceback (most recent call last):
  File "~/mythril/mythril/interfaces/cli.py", line 966, in parse_args_and_execute
    address = load_code(disassembler, args)
  File "~/mythril/mythril/interfaces/cli.py", line 717, in load_code
    address, _ = disassembler.load_from_solidity(
  File "~/mythril/mythril/mythril/mythril_disassembler.py", line 252, in load_from_solidity
    solc_binary = self.solc_binary or util.extract_binary(file)
  File "~/mythril/mythril/ethereum/util.py", line 230, in extract_binary
    version = extract_version(file_data)
  File "~/mythril/mythril/ethereum/util.py", line 194, in extract_version
    pragma_dict = parse_pragma(version_line)
  File "~/mythril/mythril/ethereum/util.py", line 158, in parse_pragma
    result = pragma.parseString(solidity_code)
  File "/usr/lib/python3/dist-packages/pyparsing.py", line 1955, in parseString
    raise exc
  File "/usr/lib/python3/dist-packages/pyparsing.py", line 3342, in parseImpl
    raise ParseException(instring, loc, self.errmsg, self)
pyparsing.ParseException: Expected Re:('\\s*[0-9]+\\s*\\.\\s*[0-9]+\\s*\\.\\s*[0-9]+'), found '0'  (at char 17), (line:1, col:18)

```