### PR TITLE
Update tox for 3.10

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python3.6, python3.9
+envlist = python3.6, python3.9, python3.10
 
 [testenv]
 deps =


### PR DESCRIPTION
py-ecc and py-evm finally support 3.10