### PR TITLE
Fully switch from mock to unittest.mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ eth-utils>=2.0.0
 hexbytes<0.3.0
 jinja2>=2.9
 MarkupSafe<2.1.0
-mock
 mypy-extensions==1.0.0
 numpy
 persistent>=4.2.0

--- a/tests/analysis/arbitrary_jump_test.py
+++ b/tests/analysis/arbitrary_jump_test.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from mythril.disassembler.disassembly import Disassembly
 from mythril.laser.smt import symbol_factory, BitVec

--- a/tests/cmd_line_test.py
+++ b/tests/cmd_line_test.py
@@ -1,6 +1,6 @@
 from subprocess import check_output, CalledProcessError, STDOUT
 from tests import BaseTestCase, TESTDATA, PROJECT_DIR, TESTS_DIR
-from mock import patch
+from unittest.mock import patch
 
 MYTH = str(PROJECT_DIR / "myth")
 

--- a/tests/concolic/concolic_tests.py
+++ b/tests/concolic/concolic_tests.py
@@ -6,7 +6,7 @@ import subprocess
 
 from copy import deepcopy
 from datetime import datetime
-from mock import patch
+from unittest.mock import patch
 from subprocess import check_output, CalledProcessError
 from tests import BaseTestCase, PROJECT_DIR, TESTDATA
 

--- a/tests/instructions/static_call_test.py
+++ b/tests/instructions/static_call_test.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from mythril.disassembler.disassembly import Disassembly
 from mythril.laser.smt import symbol_factory

--- a/tests/laser/Precompiles/ec_add_test.py
+++ b/tests/laser/Precompiles/ec_add_test.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 from eth_utils import decode_hex
 from mythril.laser.ethereum.natives import ec_add
 from py_ecc.optimized_bn128 import FQ

--- a/tests/laser/Precompiles/ecrecover_test.py
+++ b/tests/laser/Precompiles/ecrecover_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock import patch
+from unittest.mock import patch
 from eth_utils import decode_hex
 from mythril.laser.ethereum.natives import ecrecover, NativeContractException
 from mythril.laser.smt import symbol_factory

--- a/tests/laser/Precompiles/elliptic_curves_test.py
+++ b/tests/laser/Precompiles/elliptic_curves_test.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 from mythril.laser.ethereum.natives import ec_pair
 from py_ecc.optimized_bn128 import FQ
 

--- a/tests/laser/Precompiles/elliptic_mul_test.py
+++ b/tests/laser/Precompiles/elliptic_mul_test.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 from eth_utils import decode_hex
 from mythril.laser.ethereum.natives import ec_mul
 from py_ecc.optimized_bn128 import FQ

--- a/tests/laser/Precompiles/identity_test.py
+++ b/tests/laser/Precompiles/identity_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock import patch
+from unittest.mock import patch
 from eth_utils import decode_hex
 from mythril.laser.ethereum.natives import identity, NativeContractException
 from mythril.laser.smt import symbol_factory

--- a/tests/laser/Precompiles/ripemd_test.py
+++ b/tests/laser/Precompiles/ripemd_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock import patch
+from unittest.mock import patch
 from eth_utils import decode_hex
 from mythril.laser.ethereum.natives import ripemd160, NativeContractException
 from mythril.laser.smt import symbol_factory

--- a/tests/laser/Precompiles/sha256_test.py
+++ b/tests/laser/Precompiles/sha256_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mock import patch
+from unittest.mock import patch
 from eth_utils import decode_hex
 from mythril.laser.ethereum.natives import sha256, NativeContractException
 from mythril.laser.smt import symbol_factory

--- a/tests/laser/state/calldata_test.py
+++ b/tests/laser/state/calldata_test.py
@@ -3,7 +3,7 @@ from mythril.laser.ethereum.state.calldata import ConcreteCalldata, SymbolicCall
 from mythril.laser.smt import Solver, symbol_factory
 from z3 import sat, unsat
 from z3.z3types import Z3Exception
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 uninitialized_test_data = [
     ([]),  # Empty concrete calldata

--- a/tests/mythril/mythril_analyzer_test.py
+++ b/tests/mythril/mythril_analyzer_test.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from mythril.mythril import MythrilDisassembler, MythrilAnalyzer
 from mythril.analysis.report import Issue
-from mock import patch, PropertyMock
+from unittest.mock import patch, PropertyMock
 from types import SimpleNamespace
 
 


### PR DESCRIPTION
mock became part of the Python stdlib in Python 3.3, see
* https://docs.python.org/3/library/unittest.mock.html
* https://mock.readthedocs.io/en/latest/

Some tests already use unittest.mock, this PR now changes all mock imports to unittest.mock and removes mock from the requirements.txt file.