### PR TITLE
Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+      groups:
+        workflows:
+          patterns:
+            - '*'
+    - package-ecosystem: "pip"
+      directory: "/"
+      schedule:
+        interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.6
+    rev: v0.6.1
     hooks:
     -   id: ruff
         args: [--fix, --show-fixes]
@@ -42,6 +42,7 @@ repos:
     hooks:
     -   id: check-circle-ci
     -   id: check-github-workflows
+    -   id: check-dependabot
 -   repo: meta
     hooks:
     -   id: check-hooks-apply


### PR DESCRIPTION
The previous PRs https://github.com/Consensys/mythril/pull/1865, https://github.com/Consensys/mythril/pull/1867 and https://github.com/Consensys/mythril/pull/1869 removed unused imports / dependencies and explicitly updated some single dependencies (z3-solver).

This PRs adds a dependabot config that enables updates for Github Actions (multiple updates grouped into one PR) and updates of the remaining pip dependencies that are done one by one via proposed PRs. Merging this PR opens similar PRs to this one https://github.com/dbast/mythril/pull/4, where the pyparsing pinning is lifted. The automatic testing (including the multiarch container build with smoke test) of the PR and the PR description containing the changelog of the changes in newer versions brings all together to see if a pinning update is possible or not. Dependabot updates can be also ignored by just closing PRs instead of merging them.

The current outdated packages in the container based on the current pinnings in the requirements.txt:
```
docker run --rm -ti mythril/myth-dev:latest /bin/bash -c 'pip list --outdated'
Package    Version     Latest Type
---------- ----------- ------ -----
eth-bloom  1.0.4       3.0.1  wheel
eth-hash   0.3.3       0.7.0  wheel
eth-typing 4.4.0       5.0.0  wheel
eth-utils  2.3.1       5.0.0  wheel
hexbytes   0.2.3       1.2.1  wheel
MarkupSafe 2.0.1       2.1.5  wheel
matplotlib 3.9.1.post1 3.9.2  wheel
pip        23.0.1      24.2   wheel
py-solc-x  1.1.1       2.0.3  wheel
pyparsing  2.4.7       3.1.2  wheel
rlp        3.0.0       4.0.1  wheel
setuptools 72.1.0      72.2.0 wheel
wheel      0.43.0      0.44.0 wheel

[notice] A new release of pip is available: 23.0.1 -> 24.2
[notice] To update, run: pip install --upgrade pip
```