### PR TITLE
Enable+apply isort via ruff/pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,15 +10,15 @@ repos:
     hooks:
     -   id: check-toml
     -   id: check-yaml
--   repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-    -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.5.6
     hooks:
     -   id: ruff
         args: [--fix, --show-fixes]
+-   repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+    -   id: black
 -   repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.8.0-1
     hooks:

--- a/mypy-stubs/z3/__init__.pyi
+++ b/mypy-stubs/z3/__init__.pyi
@@ -1,15 +1,16 @@
 from typing import (
-    overload,
-    Tuple,
     Any,
-    List,
     Iterable,
     Iterator,
+    List,
     Optional,
+    Sequence,
+    Tuple,
     TypeVar,
     Union,
-    Sequence,
+    overload,
 )
+
 from .z3types import Ast, ContextObj
 
 class Context: ...

--- a/myth
+++ b/myth
@@ -4,8 +4,8 @@
    http://www.github.com/ConsenSys/mythril
    """
 from sys import exit
-import mythril.interfaces.cli
 
+import mythril.interfaces.cli
 
 if __name__ == "__main__":
     mythril.interfaces.cli.main()

--- a/mythril/__init__.py
+++ b/mythril/__init__.py
@@ -3,8 +3,9 @@
 __docformat__ = "restructuredtext"
 import logging
 
+from mythril.plugin.loader import MythrilPluginLoader
+
 # Accept mythril.VERSION to get mythril's current version number
 from .__version__ import __version__ as VERSION
-from mythril.plugin.loader import MythrilPluginLoader
 
 log = logging.getLogger(__name__)

--- a/mythril/analysis/call_helpers.py
+++ b/mythril/analysis/call_helpers.py
@@ -3,9 +3,9 @@ call functionality."""
 
 from typing import Union
 
-from mythril.analysis.ops import VarType, Call, get_variable
-from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.analysis.ops import Call, VarType, get_variable
 from mythril.laser.ethereum.natives import PRECOMPILE_COUNT
+from mythril.laser.ethereum.state.global_state import GlobalState
 
 
 def get_call_from_state(state: GlobalState) -> Union[Call, None]:

--- a/mythril/analysis/issue_annotation.py
+++ b/mythril/analysis/issue_annotation.py
@@ -1,9 +1,9 @@
+from copy import deepcopy
 from typing import List
 
 from mythril.analysis.report import Issue
 from mythril.laser.ethereum.state.annotation import StateAnnotation
 from mythril.laser.smt import SMTBool as Bool
-from copy import deepcopy
 
 
 class IssueAnnotation(StateAnnotation):

--- a/mythril/analysis/module/__init__.py
+++ b/mythril/analysis/module/__init__.py
@@ -1,4 +1,4 @@
-from mythril.analysis.module.base import EntryPoint, DetectionModule
+from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.module.loader import ModuleLoader
 from mythril.analysis.module.util import (
     get_detection_module_hooks,

--- a/mythril/analysis/module/base.py
+++ b/mythril/analysis/module/base.py
@@ -5,14 +5,14 @@ DetectionModules implement different analysis rules to find weaknesses and vulne
 """
 
 import logging
-from typing import List, Set, Optional, Tuple
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import List, Optional, Set, Tuple
 
 from mythril.analysis.report import Issue
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.support.support_args import args
 from mythril.support.support_utils import get_code_hash
-from abc import ABC, abstractmethod
-from enum import Enum
 
 # Get logger instance
 log = logging.getLogger(__name__)

--- a/mythril/analysis/module/loader.py
+++ b/mythril/analysis/module/loader.py
@@ -1,14 +1,13 @@
-from mythril.analysis.module.base import DetectionModule, EntryPoint
-from mythril.support.support_utils import Singleton
-from mythril.support.support_args import args
+from typing import List, Optional
 
+from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.module.modules.arbitrary_jump import ArbitraryJump
 from mythril.analysis.module.modules.arbitrary_write import ArbitraryStorage
 from mythril.analysis.module.modules.delegatecall import ArbitraryDelegateCall
+from mythril.analysis.module.modules.dependence_on_origin import TxOrigin
 from mythril.analysis.module.modules.dependence_on_predictable_vars import (
     PredictableVariables,
 )
-from mythril.analysis.module.modules.dependence_on_origin import TxOrigin
 from mythril.analysis.module.modules.ether_thief import EtherThief
 from mythril.analysis.module.modules.exceptions import Exceptions
 from mythril.analysis.module.modules.external_calls import ExternalCalls
@@ -23,13 +22,11 @@ from mythril.analysis.module.modules.transaction_order_dependence import (
     TransactionOrderDependence,
 )
 from mythril.analysis.module.modules.unchecked_retval import UncheckedRetval
-from mythril.analysis.module.modules.user_assertions import UserAssertions
 from mythril.analysis.module.modules.unexpected_ether import UnexpectedEther
-
-
+from mythril.analysis.module.modules.user_assertions import UserAssertions
 from mythril.exceptions import DetectorNotFoundError
-
-from typing import Optional, List
+from mythril.support.support_args import args
+from mythril.support.support_utils import Singleton
 
 
 class ModuleLoader(object, metaclass=Singleton):

--- a/mythril/analysis/module/modules/arbitrary_jump.py
+++ b/mythril/analysis/module/modules/arbitrary_jump.py
@@ -2,11 +2,10 @@
 
 import logging
 
-from mythril.analysis.solver import get_transaction_sequence, UnsatError
 from mythril.analysis.issue_annotation import IssueAnnotation
-from mythril.analysis.module.base import DetectionModule, Issue, EntryPoint
+from mythril.analysis.module.base import DetectionModule, EntryPoint, Issue
+from mythril.analysis.solver import UnsatError, get_transaction_sequence
 from mythril.analysis.swc_data import ARBITRARY_JUMP
-
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.smt import And, BitVec, symbol_factory
 from mythril.support.model import get_model

--- a/mythril/analysis/module/modules/arbitrary_write.py
+++ b/mythril/analysis/module/modules/arbitrary_write.py
@@ -1,12 +1,12 @@
 """This module contains the detection code for arbitrary storage write."""
 
 import logging
+
 from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.potential_issues import (
-    get_potential_issues_annotation,
     PotentialIssue,
+    get_potential_issues_annotation,
 )
-
 from mythril.analysis.swc_data import WRITE_TO_ARBITRARY_STORAGE
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.smt import symbol_factory

--- a/mythril/analysis/module/modules/delegatecall.py
+++ b/mythril/analysis/module/modules/delegatecall.py
@@ -3,19 +3,19 @@
 import logging
 from typing import List
 
+from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.potential_issues import (
-    get_potential_issues_annotation,
     PotentialIssue,
+    get_potential_issues_annotation,
 )
 from mythril.analysis.swc_data import DELEGATECALL_TO_UNTRUSTED_CONTRACT
+from mythril.exceptions import UnsatError
+from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.transaction.symbolic import ACTORS
 from mythril.laser.ethereum.transaction.transaction_models import (
     ContractCreationTransaction,
 )
-from mythril.analysis.module.base import DetectionModule, EntryPoint
-from mythril.exceptions import UnsatError
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.smt import symbol_factory, UGT
+from mythril.laser.smt import UGT, symbol_factory
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/dependence_on_origin.py
+++ b/mythril/analysis/module/modules/dependence_on_origin.py
@@ -3,15 +3,16 @@ dependence."""
 
 import logging
 from copy import copy
+from typing import List
+
+from mythril.analysis import solver
 from mythril.analysis.issue_annotation import IssueAnnotation
 from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.report import Issue
-from mythril.exceptions import UnsatError
-from mythril.analysis import solver
 from mythril.analysis.swc_data import TX_ORIGIN_USAGE
+from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.smt import And
-from typing import List
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/dependence_on_predictable_vars.py
+++ b/mythril/analysis/module/modules/dependence_on_predictable_vars.py
@@ -2,18 +2,18 @@
 dependence."""
 
 import logging
+from typing import List, cast
 
+from mythril.analysis import solver
 from mythril.analysis.issue_annotation import IssueAnnotation
 from mythril.analysis.module.base import DetectionModule, EntryPoint
-from mythril.analysis.report import Issue
-from mythril.exceptions import UnsatError
-from mythril.analysis import solver
-from mythril.laser.smt import And, ULT, symbol_factory
-from mythril.analysis.swc_data import TIMESTAMP_DEPENDENCE, WEAK_RANDOMNESS
 from mythril.analysis.module.module_helpers import is_prehook
-from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.analysis.report import Issue
+from mythril.analysis.swc_data import TIMESTAMP_DEPENDENCE, WEAK_RANDOMNESS
+from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.state.annotation import StateAnnotation
-from typing import cast, List
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.smt import ULT, And, symbol_factory
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/ether_thief.py
+++ b/mythril/analysis/module/modules/ether_thief.py
@@ -4,16 +4,16 @@ withdrawal."""
 import logging
 from copy import copy
 
+from mythril.analysis import solver
 from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.potential_issues import (
-    get_potential_issues_annotation,
     PotentialIssue,
+    get_potential_issues_annotation,
 )
-from mythril.laser.ethereum.transaction.symbolic import ACTORS
 from mythril.analysis.swc_data import UNPROTECTED_ETHER_WITHDRAWAL
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.analysis import solver
 from mythril.exceptions import UnsatError
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.transaction.symbolic import ACTORS
 from mythril.laser.smt import UGT
 
 log = logging.getLogger(__name__)

--- a/mythril/analysis/module/modules/exceptions.py
+++ b/mythril/analysis/module/modules/exceptions.py
@@ -1,20 +1,18 @@
 """This module contains the detection code for reachable exceptions."""
 
 import logging
+from typing import List, Optional, cast
 
-from typing import cast, List, Optional
 from mythril.analysis import solver
 from mythril.analysis.issue_annotation import IssueAnnotation
 from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import ASSERT_VIOLATION
 from mythril.exceptions import UnsatError
-
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.annotation import StateAnnotation
 from mythril.laser.ethereum import util
+from mythril.laser.ethereum.state.annotation import StateAnnotation
+from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.smt import And
-
 from mythril.support.support_utils import get_code_hash
 
 log = logging.getLogger(__name__)

--- a/mythril/analysis/module/modules/external_calls.py
+++ b/mythril/analysis/module/modules/external_calls.py
@@ -1,21 +1,22 @@
 """This module contains the detection code for potentially insecure low-level
 calls."""
 
+import logging
+from copy import copy
+
 from mythril.analysis import solver
+from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.potential_issues import (
     PotentialIssue,
     get_potential_issues_annotation,
 )
 from mythril.analysis.swc_data import REENTRANCY
-from mythril.laser.ethereum.state.constraints import Constraints
-from mythril.laser.ethereum.transaction.symbolic import ACTORS
-from mythril.analysis.module.base import DetectionModule, EntryPoint
-from mythril.laser.smt import UGT, symbol_factory, Or, BitVec
-from mythril.laser.ethereum.natives import PRECOMPILE_COUNT
-from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.exceptions import UnsatError
-from copy import copy
-import logging
+from mythril.laser.ethereum.natives import PRECOMPILE_COUNT
+from mythril.laser.ethereum.state.constraints import Constraints
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.transaction.symbolic import ACTORS
+from mythril.laser.smt import UGT, BitVec, Or, symbol_factory
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/integer.py
+++ b/mythril/analysis/module/modules/integer.py
@@ -1,32 +1,33 @@
 """This module contains the detection code for integer overflows and
 underflows."""
 
-from math import log2, ceil
-from typing import cast, List, Set
+import logging
+from copy import copy
+from math import ceil, log2
+from typing import List, Set, cast
+
 from mythril.analysis import solver
 from mythril.analysis.issue_annotation import IssueAnnotation
+from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import INTEGER_OVERFLOW_AND_UNDERFLOW
 from mythril.exceptions import UnsatError
-from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.state.annotation import StateAnnotation
-from mythril.analysis.module.base import DetectionModule, EntryPoint
-from copy import copy
-
+from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.smt import (
-    BVAddNoOverflow,
-    BVSubNoUnderflow,
-    BVMulNoOverflow,
-    BitVec,
-    If,
-    symbol_factory,
-    Not,
-    Expression,
-    SMTBool as Bool,
     And,
+    BitVec,
+    BVAddNoOverflow,
+    BVMulNoOverflow,
+    BVSubNoUnderflow,
+    Expression,
+    If,
+    Not,
+    symbol_factory,
 )
-
-import logging
+from mythril.laser.smt import (
+    SMTBool as Bool,
+)
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/multiple_sends.py
+++ b/mythril/analysis/module/modules/multiple_sends.py
@@ -1,17 +1,18 @@
 """This module contains the detection code to find multiple sends occurring in
 a single transaction."""
 
+import logging
 from copy import copy
-from typing import cast, List
+from typing import List, cast
+
 from mythril.analysis.issue_annotation import IssueAnnotation
-from mythril.analysis.report import Issue
-from mythril.analysis.solver import get_transaction_sequence, UnsatError
-from mythril.analysis.swc_data import MULTIPLE_SENDS
 from mythril.analysis.module.base import DetectionModule, EntryPoint
+from mythril.analysis.report import Issue
+from mythril.analysis.solver import UnsatError, get_transaction_sequence
+from mythril.analysis.swc_data import MULTIPLE_SENDS
 from mythril.laser.ethereum.state.annotation import StateAnnotation
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.smt import And
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/requirements_violation.py
+++ b/mythril/analysis/module/modules/requirements_violation.py
@@ -1,17 +1,16 @@
 """This module contains the detection code for requirement violations in a call"""
 
 import logging
+from typing import List
 
 from mythril.analysis import solver
+from mythril.analysis.issue_annotation import IssueAnnotation
 from mythril.analysis.module.base import DetectionModule
 from mythril.analysis.report import Issue
-from mythril.analysis.issue_annotation import IssueAnnotation
-from mythril.laser.smt import And
 from mythril.analysis.swc_data import REQUIREMENT_VIOLATION
 from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.state.global_state import GlobalState
-
-from typing import List
+from mythril.laser.smt import And
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/state_change_external_calls.py
+++ b/mythril/analysis/module/modules/state_change_external_calls.py
@@ -1,19 +1,19 @@
+import logging
+from copy import copy
+from typing import List, Optional, cast
+
+from mythril.analysis import solver
+from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.potential_issues import (
     PotentialIssue,
     get_potential_issues_annotation,
 )
 from mythril.analysis.swc_data import REENTRANCY
-from mythril.analysis.module.base import DetectionModule, EntryPoint
-from mythril.laser.ethereum.state.constraints import Constraints
-from mythril.laser.smt import symbol_factory, UGT, BitVec, Or
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.annotation import StateAnnotation
-from mythril.analysis import solver
 from mythril.exceptions import UnsatError
-from typing import List, cast, Optional
-from copy import copy
-
-import logging
+from mythril.laser.ethereum.state.annotation import StateAnnotation
+from mythril.laser.ethereum.state.constraints import Constraints
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.smt import UGT, BitVec, Or, symbol_factory
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/suicide.py
+++ b/mythril/analysis/module/modules/suicide.py
@@ -1,17 +1,17 @@
+import logging
+
 from mythril.analysis import solver
+from mythril.analysis.issue_annotation import IssueAnnotation
+from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import UNPROTECTED_SELFDESTRUCT
 from mythril.exceptions import UnsatError
-from mythril.analysis.issue_annotation import IssueAnnotation
-from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.transaction.symbolic import ACTORS
-from mythril.laser.smt.bool import And
 from mythril.laser.ethereum.transaction.transaction_models import (
     ContractCreationTransaction,
 )
-import logging
-
+from mythril.laser.smt.bool import And
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/transaction_order_dependence.py
+++ b/mythril/analysis/module/modules/transaction_order_dependence.py
@@ -1,17 +1,19 @@
 """This module contains the detection code for transaction order dependence."""
 
+import logging
+
 from mythril.analysis import solver
+from mythril.analysis.module.base import DetectionModule
 from mythril.analysis.potential_issues import (
     PotentialIssue,
     get_potential_issues_annotation,
 )
 from mythril.analysis.swc_data import TX_ORDER_DEPENDENCE
-from mythril.laser.ethereum.transaction.symbolic import ACTORS
-from mythril.analysis.module.base import DetectionModule
-from mythril.laser.smt import Or, SMTBool as Bool
-from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.exceptions import UnsatError
-import logging
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.transaction.symbolic import ACTORS
+from mythril.laser.smt import Or
+from mythril.laser.smt import SMTBool as Bool
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/unchecked_retval.py
+++ b/mythril/analysis/module/modules/unchecked_retval.py
@@ -1,22 +1,22 @@
 """This module contains detection code to find occurrences of calls whose
 return value remains unchecked."""
 
+import logging
 from copy import copy
-from typing import cast, List
+from typing import List, cast
+
+from typing_extensions import TypedDict
 
 from mythril.analysis import solver
 from mythril.analysis.issue_annotation import IssueAnnotation
+from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.report import Issue
 from mythril.analysis.swc_data import UNCHECKED_RET_VAL
-from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.exceptions import UnsatError
-from mythril.laser.smt import And
-from mythril.laser.smt.bitvec import BitVec
 from mythril.laser.ethereum.state.annotation import StateAnnotation
 from mythril.laser.ethereum.state.global_state import GlobalState
-
-import logging
-from typing_extensions import TypedDict
+from mythril.laser.smt import And
+from mythril.laser.smt.bitvec import BitVec
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/unexpected_ether.py
+++ b/mythril/analysis/module/modules/unexpected_ether.py
@@ -1,16 +1,16 @@
 """This module contains the detection code for unexpected ether balance."""
 
-from mythril.analysis.report import Issue
+import logging
+
 from mythril.analysis.issue_annotation import IssueAnnotation
-from mythril.analysis.swc_data import UNEXPECTED_ETHER_BALANCE
 from mythril.analysis.module.base import DetectionModule
 from mythril.analysis.module.module_helpers import is_prehook
-from mythril.laser.smt import BitVec, And
+from mythril.analysis.report import Issue
 from mythril.analysis.solver import UnsatError, get_transaction_sequence
+from mythril.analysis.swc_data import UNEXPECTED_ETHER_BALANCE
 from mythril.laser.ethereum.state.annotation import StateAnnotation
 from mythril.laser.ethereum.state.global_state import GlobalState
-
-import logging
+from mythril.laser.smt import And, BitVec
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/modules/user_assertions.py
+++ b/mythril/analysis/module/modules/user_assertions.py
@@ -1,16 +1,18 @@
 """This module contains the detection code for potentially insecure low-level
 calls."""
 
+import logging
+
+import eth_abi
+
 from mythril.analysis import solver
 from mythril.analysis.issue_annotation import IssueAnnotation
+from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.potential_issues import Issue
 from mythril.analysis.swc_data import ASSERT_VIOLATION
-from mythril.analysis.module.base import DetectionModule, EntryPoint
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.smt import Extract, And
 from mythril.exceptions import UnsatError
-import logging
-import eth_abi
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.smt import And, Extract
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/module/util.py
+++ b/mythril/analysis/module/util.py
@@ -1,10 +1,10 @@
-from collections import defaultdict
-from typing import List, Optional, Callable, Mapping, Dict
 import logging
+from collections import defaultdict
+from typing import Callable, Dict, List, Mapping, Optional
 
-from mythril.support.opcodes import OPCODES
 from mythril.analysis.module.base import DetectionModule, EntryPoint
 from mythril.analysis.module.loader import ModuleLoader
+from mythril.support.opcodes import OPCODES
 
 log = logging.getLogger(__name__)
 OP_CODE_LIST = OPCODES.keys()

--- a/mythril/analysis/potential_issues.py
+++ b/mythril/analysis/potential_issues.py
@@ -1,5 +1,5 @@
-from mythril.analysis.report import Issue
 from mythril.analysis.issue_annotation import IssueAnnotation
+from mythril.analysis.report import Issue
 from mythril.analysis.solver import get_transaction_sequence
 from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.state.annotation import StateAnnotation

--- a/mythril/analysis/report.py
+++ b/mythril/analysis/report.py
@@ -1,27 +1,28 @@
 """This module provides classes that make up an issue report."""
 
-import logging
-import re
 import json
+import logging
 import operator
+import re
 
 try:
     from eth_abi import decode
 except ImportError:
     from eth_abi import decode_abi as decode
 
-from jinja2 import PackageLoader, Environment
-from typing import Dict, Iterable, List, Any, Optional
 import hashlib
+from time import time
+from typing import Any, Dict, Iterable, List, Optional
 
+from jinja2 import Environment, PackageLoader
+
+from mythril.analysis.swc_data import SWC_TO_TITLE
 from mythril.laser.execution_info import ExecutionInfo
 from mythril.solidity.soliditycontract import SolidityContract
-from mythril.analysis.swc_data import SWC_TO_TITLE
+from mythril.support.signatures import SignatureDB
 from mythril.support.source_support import Source
 from mythril.support.start_time import StartTime
 from mythril.support.support_utils import get_code_hash
-from mythril.support.signatures import SignatureDB
-from time import time
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/security.py
+++ b/mythril/analysis/security.py
@@ -1,12 +1,12 @@
 """This module contains functionality for hooking in detection modules and
 executing them."""
 
+import logging
+from typing import List, Optional
+
 from mythril.analysis.module import ModuleLoader, reset_callback_modules
 from mythril.analysis.module.base import EntryPoint
 from mythril.analysis.report import Issue
-
-from typing import Optional, List
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/mythril/analysis/solver.py
+++ b/mythril/analysis/solver.py
@@ -1,17 +1,15 @@
 """This module contains analysis module helpers to solve path constraints."""
 
-from typing import Dict, List, Tuple, Union, Any
+import logging
+from typing import Any, Dict, List, Tuple, Union
 
 import z3
-import logging
-
 from z3 import FuncInterp
 
 from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.function_managers import (
     keccak_function_manager,
 )
-
 from mythril.laser.ethereum.state.constraints import Constraints
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.transaction import BaseTransaction

--- a/mythril/analysis/symbolic.py
+++ b/mythril/analysis/symbolic.py
@@ -1,42 +1,43 @@
 """This module contains a wrapper around LASER for extended analysis
 purposes."""
 
+from typing import List, Optional, Type, Union
+
 from mythril.analysis.module import EntryPoint, ModuleLoader, get_detection_module_hooks
-from mythril.laser.execution_info import ExecutionInfo
 from mythril.laser.ethereum import svm
+from mythril.laser.ethereum.natives import PRECOMPILE_COUNT
 from mythril.laser.ethereum.state.account import Account
 from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.strategy.basic import (
+    BasicSearchStrategy,
     BreadthFirstSearchStrategy,
     DepthFirstSearchStrategy,
     ReturnRandomNaivelyStrategy,
     ReturnWeightedRandomStrategy,
-    BasicSearchStrategy,
 )
-from mythril.laser.ethereum.strategy.constraint_strategy import DelayConstraintStrategy
 from mythril.laser.ethereum.strategy.beam import BeamSearch
-from mythril.laser.ethereum.natives import PRECOMPILE_COUNT
+from mythril.laser.ethereum.strategy.constraint_strategy import DelayConstraintStrategy
+from mythril.laser.ethereum.strategy.extensions.bounded_loops import (
+    BoundedLoopsStrategy,
+)
 from mythril.laser.ethereum.transaction.symbolic import ACTORS
 from mythril.laser.ethereum.tx_prioritiser import RfTxPrioritiser
-
+from mythril.laser.execution_info import ExecutionInfo
 from mythril.laser.plugin.loader import LaserPluginLoader
 from mythril.laser.plugin.plugins import (
     CallDepthLimitBuilder,
-    CoveragePluginBuilder,
     CoverageMetricsPluginBuilder,
+    CoveragePluginBuilder,
     DependencyPrunerBuilder,
     InstructionProfilerBuilder,
     MutationPrunerBuilder,
     StateMergePluginBuilder,
     SymbolicSummaryPluginBuilder,
 )
-from mythril.laser.ethereum.strategy.extensions.bounded_loops import (
-    BoundedLoopsStrategy,
-)
-from mythril.laser.smt import symbol_factory, BitVec
-from mythril.support.support_args import args
-from typing import Union, List, Type, Optional
+from mythril.laser.smt import BitVec, symbol_factory
 from mythril.solidity.soliditycontract import EVMContract, SolidityContract
+from mythril.support.support_args import args
+
 from .ops import Call, VarType, get_variable
 
 

--- a/mythril/analysis/traceexplore.py
+++ b/mythril/analysis/traceexplore.py
@@ -1,10 +1,12 @@
 """This module provides a function to convert a state space into a set of state
 nodes and transition edges."""
 
-from z3 import Z3Exception
-from mythril.laser.smt import simplify
-from mythril.laser.ethereum.svm import NodeFlags
 import re
+
+from z3 import Z3Exception
+
+from mythril.laser.ethereum.svm import NodeFlags
+from mythril.laser.smt import simplify
 
 colors = [
     {

--- a/mythril/concolic/concolic_execution.py
+++ b/mythril/concolic/concolic_execution.py
@@ -1,16 +1,16 @@
-from datetime import datetime
-from typing import Dict, List, Any
 from copy import deepcopy
+from datetime import datetime
+from typing import Any, Dict, List
 
 from mythril.concolic.concrete_data import ConcreteData
 from mythril.concolic.find_trace import concrete_execution
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.strategy.concolic import ConcolicStrategy
 from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.ethereum.state.world_state import WorldState
+from mythril.laser.ethereum.time_handler import time_handler
 from mythril.laser.ethereum.transaction.symbolic import execute_transaction
 from mythril.laser.ethereum.transaction.transaction_models import tx_id_manager
 from mythril.laser.smt import symbol_factory
-from mythril.laser.ethereum.time_handler import time_handler
 from mythril.support.support_args import args
 
 

--- a/mythril/concolic/concrete_data.py
+++ b/mythril/concolic/concrete_data.py
@@ -1,4 +1,5 @@
 from typing import Dict, List
+
 from typing_extensions import TypedDict
 
 

--- a/mythril/concolic/find_trace.py
+++ b/mythril/concolic/find_trace.py
@@ -1,21 +1,19 @@
 import binascii
-
 from copy import deepcopy
 from datetime import datetime
 from typing import List, Tuple
 
 from mythril.concolic.concrete_data import ConcreteData
-
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.state.account import Account
+from mythril.laser.ethereum.state.world_state import WorldState
+from mythril.laser.ethereum.svm import LaserEVM
 from mythril.laser.ethereum.time_handler import time_handler
-from mythril.laser.plugin.plugins import TraceFinderBuilder
 from mythril.laser.ethereum.transaction.concolic import execute_transaction
-from mythril.laser.plugin.loader import LaserPluginLoader
-from mythril.laser.smt import symbol_factory
 from mythril.laser.ethereum.transaction.transaction_models import tx_id_manager
+from mythril.laser.plugin.loader import LaserPluginLoader
+from mythril.laser.plugin.plugins import TraceFinderBuilder
+from mythril.laser.smt import symbol_factory
 from mythril.support.support_args import args
 
 

--- a/mythril/disassembler/asm.py
+++ b/mythril/disassembler/asm.py
@@ -11,7 +11,7 @@ except ImportError:
 from functools import lru_cache
 
 from mythril.ethereum import util
-from mythril.support.opcodes import OPCODES, ADDRESS, ADDRESS_OPCODE_MAPPING
+from mythril.support.opcodes import ADDRESS, ADDRESS_OPCODE_MAPPING, OPCODES
 
 regex_PUSH = re.compile(r"^PUSH(\d*)$")
 

--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -1,10 +1,10 @@
 """This module contains the class used to represent disassembly code."""
 
-from mythril.ethereum import util
-from mythril.disassembler import asm
-from mythril.support.signatures import SignatureDB
-
 from typing import Dict, List, Tuple
+
+from mythril.disassembler import asm
+from mythril.ethereum import util
+from mythril.support.signatures import SignatureDB
 
 
 class Disassembly(object):

--- a/mythril/ethereum/evmcontract.py
+++ b/mythril/ethereum/evmcontract.py
@@ -1,13 +1,13 @@
 """This module contains the class representing EVM contracts, aka Smart
 Contracts."""
 
-import re
 import logging
+import re
+
 import persistent
 
-from mythril.support.support_utils import sha3
 from mythril.disassembler.disassembly import Disassembly
-from mythril.support.support_utils import get_code_hash
+from mythril.support.support_utils import get_code_hash, sha3
 
 log = logging.getLogger(__name__)
 

--- a/mythril/ethereum/util.py
+++ b/mythril/ethereum/util.py
@@ -3,23 +3,21 @@ solc integration."""
 
 import binascii
 import json
+import logging
 import os
 import platform
-import logging
 import typing
-
-from requests.exceptions import ConnectionError
+from json.decoder import JSONDecodeError
 from subprocess import PIPE, Popen
 from typing import Tuple
 
-from json.decoder import JSONDecodeError
 import semantic_version as semver
-from pyparsing import Word, Optional, Regex, Combine
+import solcx
+from pyparsing import Combine, Optional, Regex, Word
+from requests.exceptions import ConnectionError
 
 from mythril.exceptions import CompilerError
 from mythril.support.support_args import args
-
-import solcx
 
 log = logging.getLogger(__name__)
 

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -10,26 +10,23 @@ import json
 import logging
 import os
 import sys
-
-import coloredlogs
 import traceback
+from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
 from ast import literal_eval
 
-from argparse import ArgumentParser, Namespace, RawTextHelpFormatter
-from mythril.concolic import concolic_execution
-from mythril.exceptions import (
-    DetectorNotFoundError,
-    CriticalError,
-)
-from mythril.laser.ethereum.transaction.symbolic import ACTORS
-from mythril.plugin.loader import MythrilPluginLoader
-
-from mythril.mythril import MythrilAnalyzer, MythrilDisassembler, MythrilConfig
-
-from mythril.analysis.module import ModuleLoader
-from mythril.analysis.report import Report
+import coloredlogs
 
 from mythril.__version__ import __version__ as VERSION
+from mythril.analysis.module import ModuleLoader
+from mythril.analysis.report import Report
+from mythril.concolic import concolic_execution
+from mythril.exceptions import (
+    CriticalError,
+    DetectorNotFoundError,
+)
+from mythril.laser.ethereum.transaction.symbolic import ACTORS
+from mythril.mythril import MythrilAnalyzer, MythrilConfig, MythrilDisassembler
+from mythril.plugin.loader import MythrilPluginLoader
 
 # Initialise core Mythril Component
 _ = MythrilPluginLoader()

--- a/mythril/interfaces/epic.py
+++ b/mythril/interfaces/epic.py
@@ -10,6 +10,7 @@
 
 # https://github.com/tehmaze/lolcat
 
+import argparse
 import atexit
 import math
 import os
@@ -17,7 +18,6 @@ import random
 import re
 import sys
 import time
-import argparse
 
 PY3 = sys.version_info >= (3,)
 

--- a/mythril/laser/ethereum/call.py
+++ b/mythril/laser/ethereum/call.py
@@ -4,23 +4,23 @@ parameters for the new global state."""
 
 import logging
 import re
-from typing import Union, List, cast, Optional
+from typing import List, Optional, Union, cast
+
 from eth.constants import GAS_CALLSTIPEND
 
 import mythril.laser.ethereum.util as util
-from mythril.laser.ethereum.util import insert_ret_val
 from mythril.laser.ethereum import natives
 from mythril.laser.ethereum.instruction_data import calculate_native_gas
-from mythril.laser.ethereum.state.account import Account
 from mythril.laser.ethereum.natives import PRECOMPILE_COUNT, PRECOMPILE_FUNCTIONS
+from mythril.laser.ethereum.state.account import Account
 from mythril.laser.ethereum.state.calldata import (
     BaseCalldata,
-    SymbolicCalldata,
     ConcreteCalldata,
+    SymbolicCalldata,
 )
 from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.smt import BitVec, If
-from mythril.laser.smt import simplify, Expression, symbol_factory
+from mythril.laser.ethereum.util import insert_ret_val
+from mythril.laser.smt import BitVec, Expression, If, simplify, symbol_factory
 from mythril.support.loader import DynLoader
 
 """

--- a/mythril/laser/ethereum/cfg.py
+++ b/mythril/laser/ethereum/cfg.py
@@ -1,10 +1,11 @@
 """This module."""
 
 from enum import Enum
-from typing import Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List
+
+from flags import Flags
 
 from mythril.laser.ethereum.state.constraints import Constraints
-from flags import Flags
 
 if TYPE_CHECKING:
     from mythril.laser.ethereum.state.global_state import GlobalState

--- a/mythril/laser/ethereum/cheat_code.py
+++ b/mythril/laser/ethereum/cheat_code.py
@@ -1,12 +1,11 @@
 from typing import Union
 
-from mythril.laser.ethereum.util import insert_ret_val
 from mythril.laser.ethereum.state.calldata import (
     BaseCalldata,
 )
 from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.smt import BitVec
-from mythril.laser.smt import Expression
+from mythril.laser.ethereum.util import insert_ret_val
+from mythril.laser.smt import BitVec, Expression
 
 
 class hevm_cheat_code:

--- a/mythril/laser/ethereum/function_managers/__init__.py
+++ b/mythril/laser/ethereum/function_managers/__init__.py
@@ -1,2 +1,2 @@
 from .exponent_function_manager import exponent_function_manager
-from .keccak_function_manager import keccak_function_manager, KeccakFunctionManager
+from .keccak_function_manager import KeccakFunctionManager, keccak_function_manager

--- a/mythril/laser/ethereum/function_managers/exponent_function_manager.py
+++ b/mythril/laser/ethereum/function_managers/exponent_function_manager.py
@@ -1,14 +1,15 @@
 import logging
 from typing import Tuple
 
-
 from mythril.laser.smt import (
     And,
     BitVec,
-    SMTBool as Bool,
     Function,
     URem,
     symbol_factory,
+)
+from mythril.laser.smt import (
+    SMTBool as Bool,
 )
 
 log = logging.getLogger(__name__)

--- a/mythril/laser/ethereum/function_managers/keccak_function_manager.py
+++ b/mythril/laser/ethereum/function_managers/keccak_function_manager.py
@@ -1,20 +1,20 @@
+import logging
+from typing import Dict, List, Optional, Tuple
+
 from mythril.laser.smt import (
+    ULE,
+    ULT,
+    And,
     BitVec,
     Function,
+    Or,
     URem,
     symbol_factory,
-    ULE,
-    And,
-    ULT,
-    SMTBool as Bool,
-    Or,
 )
-
+from mythril.laser.smt import (
+    SMTBool as Bool,
+)
 from mythril.support.support_utils import sha3
-from typing import Dict, Tuple, List, Optional
-
-import logging
-
 
 TOTAL_PARTS = 10**40
 PART = (2**256 - 1) // TOTAL_PARTS

--- a/mythril/laser/ethereum/instruction_data.py
+++ b/mythril/laser/ethereum/instruction_data.py
@@ -1,17 +1,19 @@
-from eth._utils.numeric import ceil32
 from typing import Tuple
-from mythril.support.opcodes import OPCODES, STACK, GAS
+
+from eth._utils.numeric import ceil32
 from eth.constants import (
     GAS_ECRECOVER,
-    GAS_SHA256WORD,
-    GAS_SHA256,
-    GAS_RIPEMD160,
-    GAS_RIPEMD160WORD,
     GAS_IDENTITY,
     GAS_IDENTITYWORD,
-    GAS_SHA3WORD,
+    GAS_RIPEMD160,
+    GAS_RIPEMD160WORD,
     GAS_SHA3,
+    GAS_SHA3WORD,
+    GAS_SHA256,
+    GAS_SHA256WORD,
 )
+
+from mythril.support.opcodes import GAS, OPCODES, STACK
 
 
 def calculate_sha3_gas(length: int):

--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -2,70 +2,65 @@
 transitions between them."""
 
 import logging
-
 from copy import copy, deepcopy
-from typing import cast, Callable, List, Union, Tuple
-
-from mythril.exceptions import UnsatError
-from mythril.laser.smt import (
-    Extract,
-    Expression,
-    UDiv,
-    simplify,
-    Concat,
-    ULT,
-    UGT,
-    BitVec,
-    is_false,
-    URem,
-    SRem,
-    If,
-    SMTBool as Bool,
-    Not,
-    LShR,
-    UGE,
-)
-from mythril.laser.smt import symbol_factory
-
-from mythril.disassembler.disassembly import Disassembly
-
-from mythril.laser.ethereum.state.calldata import ConcreteCalldata, SymbolicCalldata
+from typing import Callable, List, Tuple, Union, cast
 
 import mythril.laser.ethereum.util as helper
+from mythril.disassembler.disassembly import Disassembly
+from mythril.exceptions import UnsatError
 from mythril.laser.ethereum import util
-from mythril.laser.ethereum.function_managers import (
-    keccak_function_manager,
-    exponent_function_manager,
-)
-
 from mythril.laser.ethereum.call import (
+    SYMBOLIC_CALLDATA_SIZE,
+    get_call_data,
     get_call_parameters,
     native_call,
-    get_call_data,
-    SYMBOLIC_CALLDATA_SIZE,
 )
 from mythril.laser.ethereum.evm_exceptions import (
-    VmException,
-    StackUnderflowException,
-    InvalidJumpDestination,
     InvalidInstruction,
+    InvalidJumpDestination,
     OutOfGasException,
+    StackUnderflowException,
+    VmException,
     WriteProtection,
 )
-from mythril.laser.ethereum.instruction_data import get_opcode_gas, calculate_sha3_gas
+from mythril.laser.ethereum.function_managers import (
+    exponent_function_manager,
+    keccak_function_manager,
+)
+from mythril.laser.ethereum.instruction_data import calculate_sha3_gas, get_opcode_gas
+from mythril.laser.ethereum.state.calldata import ConcreteCalldata, SymbolicCalldata
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.state.return_data import ReturnData
-
 from mythril.laser.ethereum.transaction import (
+    ContractCreationTransaction,
     MessageCallTransaction,
     TransactionStartSignal,
-    ContractCreationTransaction,
     tx_id_manager,
 )
+from mythril.laser.smt import (
+    UGE,
+    UGT,
+    ULT,
+    BitVec,
+    Concat,
+    Expression,
+    Extract,
+    If,
+    LShR,
+    Not,
+    SRem,
+    UDiv,
+    URem,
+    is_false,
+    simplify,
+    symbol_factory,
+)
+from mythril.laser.smt import (
+    SMTBool as Bool,
+)
+from mythril.support.loader import DynLoader
 from mythril.support.model import get_model
 from mythril.support.support_utils import get_code_hash
-
-from mythril.support.loader import DynLoader
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/ethereum/natives.py
+++ b/mythril/laser/ethereum/natives.py
@@ -2,24 +2,21 @@
 
 import hashlib
 import logging
-import blake2b
-import coincurve
-
 from typing import List
 
-from py_ecc.secp256k1 import N as secp256k1n
-from py_ecc.secp256k1 import ecdsa_raw_recover
+import blake2b
+import coincurve
 import py_ecc.optimized_bn128 as bn128
-
-from rlp.utils import ALL_BYTES
-from eth_utils import ValidationError
 from eth._utils.blake2.coders import extract_blake2b_parameters
 from eth._utils.bn128 import validate_point
+from eth_utils import ValidationError, big_endian_to_int, int_to_big_endian
+from py_ecc.secp256k1 import N as secp256k1n
+from py_ecc.secp256k1 import ecdsa_raw_recover
+from rlp.utils import ALL_BYTES
 
-from mythril.support.support_utils import sha3, zpad
 from mythril.laser.ethereum.state.calldata import BaseCalldata, ConcreteCalldata
-from mythril.laser.ethereum.util import extract_copy, extract32
-from eth_utils import int_to_big_endian, big_endian_to_int
+from mythril.laser.ethereum.util import extract32, extract_copy
+from mythril.support.support_utils import sha3, zpad
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/ethereum/state/account.py
+++ b/mythril/laser/ethereum/state/account.py
@@ -5,12 +5,11 @@ This includes classes representing accounts and their storage.
 
 import logging
 from copy import copy, deepcopy
-from typing import Any, Dict, Union, Set
+from typing import Any, Dict, Set, Union
 
-
-from mythril.laser.smt import Array, K, BitVec, simplify, BaseArray, If, SMTBool as Bool
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.smt import symbol_factory
+from mythril.laser.smt import Array, BaseArray, BitVec, If, K, simplify, symbol_factory
+from mythril.laser.smt import SMTBool as Bool
 from mythril.support.support_args import args
 
 log = logging.getLogger(__name__)

--- a/mythril/laser/ethereum/state/calldata.py
+++ b/mythril/laser/ethereum/state/calldata.py
@@ -1,26 +1,24 @@
 """This module declares classes to represent call data."""
 
-from typing import cast, Union, Tuple, List
+from typing import Any, List, Tuple, Union, cast
 
-
-from typing import Any
-
-from z3 import Model, unsat, unknown
+from z3 import Model, unknown, unsat
 from z3.z3types import Z3Exception
 
 from mythril.laser.ethereum.util import get_concrete_int
-
 from mythril.laser.smt import (
     Array,
     BitVec,
-    SMTBool as Bool,
     Concat,
     Expression,
     If,
     K,
+    Solver,
     simplify,
     symbol_factory,
-    Solver,
+)
+from mythril.laser.smt import (
+    SMTBool as Bool,
 )
 
 

--- a/mythril/laser/ethereum/state/constraints.py
+++ b/mythril/laser/ethereum/state/constraints.py
@@ -1,13 +1,15 @@
 """This module contains the class used to represent state-change constraints in
 the call graph."""
 
-from mythril.exceptions import UnsatError, SolverTimeOutException
-from mythril.laser.smt import symbol_factory, simplify, SMTBool as Bool
-from mythril.support.model import get_model
-from mythril.laser.ethereum.function_managers import keccak_function_manager
-from mythril.laser.smt.model import Model
 from copy import copy
 from typing import Iterable, List, Optional, Union
+
+from mythril.exceptions import SolverTimeOutException, UnsatError
+from mythril.laser.ethereum.function_managers import keccak_function_manager
+from mythril.laser.smt import SMTBool as Bool
+from mythril.laser.smt import simplify, symbol_factory
+from mythril.laser.smt.model import Model
+from mythril.support.model import get_model
 
 
 class Constraints(list):

--- a/mythril/laser/ethereum/state/global_state.py
+++ b/mythril/laser/ethereum/state/global_state.py
@@ -1,21 +1,21 @@
 """This module contains a representation of the global execution state."""
 
-from typing import Dict, Union, List, Iterable, TYPE_CHECKING
-
 from copy import copy, deepcopy
+from typing import TYPE_CHECKING, Dict, Iterable, List, Union
+
 from z3 import BitVec
 
-from mythril.laser.smt import symbol_factory
 from mythril.laser.ethereum.cfg import Node
+from mythril.laser.ethereum.state.annotation import StateAnnotation
 from mythril.laser.ethereum.state.environment import Environment
 from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.annotation import StateAnnotation
+from mythril.laser.smt import symbol_factory
 
 if TYPE_CHECKING:
     from mythril.laser.ethereum.state.world_state import WorldState
     from mythril.laser.ethereum.transaction.transaction_models import (
-        MessageCallTransaction,
         ContractCreationTransaction,
+        MessageCallTransaction,
     )
 
 

--- a/mythril/laser/ethereum/state/machine_state.py
+++ b/mythril/laser/ethereum/state/machine_state.py
@@ -2,18 +2,19 @@
 stack."""
 
 from copy import copy
-from typing import cast, Sized, Union, Any, List, Dict, Optional
+from typing import Any, Dict, List, Optional, Sized, Union, cast
 
-from mythril.laser.smt import BitVec, SMTBool as Bool, If, Expression, symbol_factory
 from eth._utils.numeric import ceil32
-
 from eth.constants import GAS_MEMORY, GAS_MEMORY_QUADRATIC_DENOMINATOR
+
 from mythril.laser.ethereum.evm_exceptions import (
+    OutOfGasException,
     StackOverflowException,
     StackUnderflowException,
-    OutOfGasException,
 )
 from mythril.laser.ethereum.state.memory import Memory
+from mythril.laser.smt import BitVec, Expression, If, symbol_factory
+from mythril.laser.smt import SMTBool as Bool
 
 
 class MachineStack(list):

--- a/mythril/laser/ethereum/state/memory.py
+++ b/mythril/laser/ethereum/state/memory.py
@@ -1,18 +1,21 @@
 """This module contains a representation of a smart contract's memory."""
 
 from copy import copy
-from typing import cast, Dict, List, Union, overload
+from typing import Dict, List, Union, cast, overload
+
 from z3 import Z3Exception
 
 from mythril.laser.ethereum import util
 from mythril.laser.smt import (
     BitVec,
-    SMTBool as Bool,
     Concat,
     Extract,
     If,
     simplify,
     symbol_factory,
+)
+from mythril.laser.smt import (
+    SMTBool as Bool,
 )
 
 

--- a/mythril/laser/ethereum/state/transient_storage.py
+++ b/mythril/laser/ethereum/state/transient_storage.py
@@ -1,5 +1,6 @@
-from mythril.laser.smt import K, Concat, simplify
 from copy import copy, deepcopy
+
+from mythril.laser.smt import Concat, K, simplify
 
 
 class TransientStorage:

--- a/mythril/laser/ethereum/state/world_state.py
+++ b/mythril/laser/ethereum/state/world_state.py
@@ -2,15 +2,16 @@
 
 from copy import copy, deepcopy
 from random import randint
-from typing import Dict, List, Iterator, Optional, TYPE_CHECKING
-from eth._utils.address import generate_contract_address
-from mythril.laser.ethereum.state.transient_storage import TransientStorage
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional
 
-from mythril.support.loader import DynLoader
-from mythril.laser.smt import symbol_factory, Array, BitVec
+from eth._utils.address import generate_contract_address
+
 from mythril.laser.ethereum.state.account import Account
 from mythril.laser.ethereum.state.annotation import StateAnnotation
 from mythril.laser.ethereum.state.constraints import Constraints
+from mythril.laser.ethereum.state.transient_storage import TransientStorage
+from mythril.laser.smt import Array, BitVec, symbol_factory
+from mythril.support.loader import DynLoader
 
 if TYPE_CHECKING:
     from mythril.laser.ethereum.cfg import Node

--- a/mythril/laser/ethereum/strategy/__init__.py
+++ b/mythril/laser/ethereum/strategy/__init__.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List
+
 from mythril.laser.ethereum.state.global_state import GlobalState
 
 

--- a/mythril/laser/ethereum/strategy/basic.py
+++ b/mythril/laser/ethereum/strategy/basic.py
@@ -1,10 +1,10 @@
 """This module implements basic symbolic execution search strategies."""
 
-from random import randrange
+from random import choices, randrange
 
 from mythril.laser.ethereum.state.global_state import GlobalState
+
 from . import BasicSearchStrategy
-from random import choices
 
 
 class DepthFirstSearchStrategy(BasicSearchStrategy):

--- a/mythril/laser/ethereum/strategy/beam.py
+++ b/mythril/laser/ethereum/strategy/beam.py
@@ -1,4 +1,5 @@
 from mythril.laser.ethereum.state.global_state import GlobalState
+
 from . import BasicSearchStrategy
 
 

--- a/mythril/laser/ethereum/strategy/concolic.py
+++ b/mythril/laser/ethereum/strategy/concolic.py
@@ -1,16 +1,17 @@
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.constraints import Constraints
-from mythril.laser.ethereum.state.annotation import StateAnnotation
-from mythril.analysis.solver import get_transaction_sequence
-from mythril.laser.smt import Not
-from mythril.exceptions import UnsatError
-
-from functools import reduce
-from typing import Dict, cast, List, Any, Tuple
-from copy import copy
-from . import CriterionSearchStrategy
 import logging
 import operator
+from copy import copy
+from functools import reduce
+from typing import Any, Dict, List, Tuple, cast
+
+from mythril.analysis.solver import get_transaction_sequence
+from mythril.exceptions import UnsatError
+from mythril.laser.ethereum.state.annotation import StateAnnotation
+from mythril.laser.ethereum.state.constraints import Constraints
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.smt import Not
+
+from . import CriterionSearchStrategy
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/ethereum/strategy/constraint_strategy.py
+++ b/mythril/laser/ethereum/strategy/constraint_strategy.py
@@ -1,8 +1,8 @@
+import logging
+
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.strategy.basic import BasicSearchStrategy
 from mythril.support.support_utils import ModelCache
-
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
+++ b/mythril/laser/ethereum/strategy/extensions/bounded_loops.py
@@ -1,11 +1,11 @@
+import logging
+from copy import copy
+from typing import Dict, List, cast
+
+from mythril.laser.ethereum.state.annotation import StateAnnotation
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.strategy.basic import BasicSearchStrategy
-from mythril.laser.ethereum.state.annotation import StateAnnotation
 from mythril.laser.ethereum.transaction import ContractCreationTransaction
-from typing import Dict, cast, List
-from copy import copy
-import logging
-
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/ethereum/svm.py
+++ b/mythril/laser/ethereum/svm.py
@@ -1,27 +1,23 @@
 """This module implements the main symbolic execution engine."""
 
 import logging
+import random
+from abc import ABCMeta
 from collections import defaultdict
 from copy import copy
 from datetime import datetime, timedelta
-import random
-from typing import Callable, Dict, DefaultDict, List, Tuple, Optional
+from typing import Callable, DefaultDict, Dict, List, Optional, Tuple
 
-from mythril.support.opcodes import OPCODES
 from mythril.analysis.potential_issues import check_potential_issues
-from mythril.laser.execution_info import ExecutionInfo
-from mythril.laser.ethereum.cfg import NodeFlags, Node, Edge, JumpType
+from mythril.laser.ethereum.cfg import Edge, JumpType, Node, NodeFlags
 from mythril.laser.ethereum.evm_exceptions import StackUnderflowException, VmException
-from mythril.laser.ethereum.instructions import Instruction
 from mythril.laser.ethereum.instruction_data import get_required_stack_elements
-from mythril.laser.plugin.signals import PluginSkipWorldState, PluginSkipState
+from mythril.laser.ethereum.instructions import Instruction
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.strategy.basic import DepthFirstSearchStrategy
 from mythril.laser.ethereum.strategy.constraint_strategy import DelayConstraintStrategy
-from abc import ABCMeta
 from mythril.laser.ethereum.time_handler import time_handler
-
 from mythril.laser.ethereum.transaction import (
     ContractCreationTransaction,
     TransactionEndSignal,
@@ -29,7 +25,10 @@ from mythril.laser.ethereum.transaction import (
     execute_contract_creation,
     execute_message_call,
 )
-from mythril.laser.smt import And, symbol_factory, simplify
+from mythril.laser.execution_info import ExecutionInfo
+from mythril.laser.plugin.signals import PluginSkipState, PluginSkipWorldState
+from mythril.laser.smt import And, simplify, symbol_factory
+from mythril.support.opcodes import OPCODES
 from mythril.support.support_args import args
 
 log = logging.getLogger(__name__)

--- a/mythril/laser/ethereum/time_handler.py
+++ b/mythril/laser/ethereum/time_handler.py
@@ -1,4 +1,5 @@
 import time
+
 from mythril.support.support_utils import Singleton
 
 

--- a/mythril/laser/ethereum/transaction/__init__.py
+++ b/mythril/laser/ethereum/transaction/__init__.py
@@ -1,5 +1,5 @@
-from mythril.laser.ethereum.transaction.transaction_models import *
 from mythril.laser.ethereum.transaction.symbolic import (
-    execute_message_call,
     execute_contract_creation,
+    execute_message_call,
 )
+from mythril.laser.ethereum.transaction.transaction_models import *

--- a/mythril/laser/ethereum/transaction/concolic.py
+++ b/mythril/laser/ethereum/transaction/concolic.py
@@ -2,21 +2,20 @@
 calls."""
 
 import binascii
-
 from typing import List, Union
 
-from mythril.exceptions import IllegalArgumentError
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.cfg import Node, Edge, JumpType
-from mythril.laser.smt import symbol_factory
+from mythril.exceptions import IllegalArgumentError
+from mythril.laser.ethereum.cfg import Edge, JumpType, Node
 from mythril.laser.ethereum.state.calldata import ConcreteCalldata
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import (
-    MessageCallTransaction,
     ContractCreationTransaction,
+    MessageCallTransaction,
     tx_id_manager,
 )
+from mythril.laser.smt import symbol_factory
 
 
 def execute_contract_creation(

--- a/mythril/laser/ethereum/transaction/symbolic.py
+++ b/mythril/laser/ethereum/transaction/symbolic.py
@@ -2,22 +2,21 @@
 symbolic values."""
 
 import logging
-from typing import Optional, List
-
+from typing import List, Optional
 
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.cfg import Node, Edge, JumpType
+from mythril.laser.ethereum.cfg import Edge, JumpType, Node
 from mythril.laser.ethereum.state.account import Account
 from mythril.laser.ethereum.state.calldata import SymbolicCalldata
 from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import (
-    MessageCallTransaction,
-    ContractCreationTransaction,
-    tx_id_manager,
     BaseTransaction,
+    ContractCreationTransaction,
+    MessageCallTransaction,
+    tx_id_manager,
 )
-from mythril.laser.smt import symbol_factory, Or, SMTBool as Bool, BitVec
-
+from mythril.laser.smt import BitVec, Or, symbol_factory
+from mythril.laser.smt import SMTBool as Bool
 
 FUNCTION_HASH_BYTE_LENGTH = 4
 

--- a/mythril/laser/ethereum/transaction/transaction_models.py
+++ b/mythril/laser/ethereum/transaction/transaction_models.py
@@ -1,19 +1,24 @@
 """This module contains the transaction models used throughout LASER's symbolic
 execution."""
 
+import logging
 from copy import deepcopy
+from typing import Optional, Union
+
 from z3 import ExprRef
-from typing import Union, Optional
-from mythril.support.support_utils import Singleton
-from mythril.laser.ethereum.state.calldata import ConcreteCalldata
+
 from mythril.laser.ethereum.state.account import Account
-from mythril.laser.ethereum.state.calldata import BaseCalldata, SymbolicCalldata
-from mythril.laser.ethereum.state.return_data import ReturnData
+from mythril.laser.ethereum.state.calldata import (
+    BaseCalldata,
+    ConcreteCalldata,
+    SymbolicCalldata,
+)
 from mythril.laser.ethereum.state.environment import Environment
 from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.return_data import ReturnData
 from mythril.laser.ethereum.state.world_state import WorldState
-from mythril.laser.smt import symbol_factory, UGE, BitVec
-import logging
+from mythril.laser.smt import UGE, BitVec, symbol_factory
+from mythril.support.support_utils import Singleton
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/ethereum/tx_prioritiser/rf_prioritiser.py
+++ b/mythril/laser/ethereum/tx_prioritiser/rf_prioritiser.py
@@ -1,7 +1,7 @@
-import pickle
-import numpy as np
-
 import logging
+import pickle
+
+import numpy as np
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/ethereum/util.py
+++ b/mythril/laser/ethereum/util.py
@@ -2,18 +2,20 @@
 LASER."""
 
 import re
-from typing import Dict, List, Union, TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Dict, List, Union, cast
 
 if TYPE_CHECKING:
-    from mythril.laser.ethereum.state.machine_state import MachineState
     from mythril.laser.ethereum.state.global_state import GlobalState
+    from mythril.laser.ethereum.state.machine_state import MachineState
 from mythril.laser.smt import (
     BitVec,
-    SMTBool as Bool,
     Expression,
     If,
     simplify,
     symbol_factory,
+)
+from mythril.laser.smt import (
+    SMTBool as Bool,
 )
 
 TT256 = 2**256

--- a/mythril/laser/plugin/builder.py
+++ b/mythril/laser/plugin/builder.py
@@ -1,6 +1,6 @@
-from mythril.laser.plugin.interface import LaserPlugin
-
 from abc import ABC, abstractmethod
+
+from mythril.laser.plugin.interface import LaserPlugin
 
 
 class PluginBuilder(ABC):

--- a/mythril/laser/plugin/loader.py
+++ b/mythril/laser/plugin/loader.py
@@ -2,8 +2,8 @@ import logging
 from typing import Dict, List, Optional
 
 from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.plugin.interface import LaserPlugin
 from mythril.laser.plugin.builder import PluginBuilder
+from mythril.laser.plugin.interface import LaserPlugin
 from mythril.support.support_utils import Singleton
 
 log = logging.getLogger(__name__)

--- a/mythril/laser/plugin/plugins/benchmark.py
+++ b/mythril/laser/plugin/plugins/benchmark.py
@@ -1,9 +1,11 @@
-from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.plugin.interface import LaserPlugin
-from mythril.laser.plugin.builder import PluginBuilder
-from time import time
-import matplotlib.pyplot as plt
 import logging
+from time import time
+
+import matplotlib.pyplot as plt
+
+from mythril.laser.ethereum.svm import LaserEVM
+from mythril.laser.plugin.builder import PluginBuilder
+from mythril.laser.plugin.interface import LaserPlugin
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/plugin/plugins/call_depth_limiter.py
+++ b/mythril/laser/plugin/plugins/call_depth_limiter.py
@@ -1,8 +1,8 @@
-from mythril.laser.plugin.signals import PluginSkipState
-from mythril.laser.plugin.interface import LaserPlugin
-from mythril.laser.plugin.builder import PluginBuilder
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.svm import LaserEVM
+from mythril.laser.plugin.builder import PluginBuilder
+from mythril.laser.plugin.interface import LaserPlugin
+from mythril.laser.plugin.signals import PluginSkipState
 
 
 class CallDepthLimitBuilder(PluginBuilder):

--- a/mythril/laser/plugin/plugins/coverage/coverage_plugin.py
+++ b/mythril/laser/plugin/plugins/coverage/coverage_plugin.py
@@ -1,11 +1,10 @@
-from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.plugin.interface import LaserPlugin
-from mythril.laser.plugin.builder import PluginBuilder
-from mythril.laser.ethereum.state.global_state import GlobalState
-
-from typing import Dict, Tuple, List
-
 import logging
+from typing import Dict, List, Tuple
+
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.svm import LaserEVM
+from mythril.laser.plugin.builder import PluginBuilder
+from mythril.laser.plugin.interface import LaserPlugin
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/plugin/plugins/coverage/coverage_strategy.py
+++ b/mythril/laser/plugin/plugins/coverage/coverage_strategy.py
@@ -1,5 +1,5 @@
-from mythril.laser.ethereum.strategy import BasicSearchStrategy
 from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.strategy import BasicSearchStrategy
 from mythril.laser.plugin.plugins.coverage import InstructionCoveragePlugin
 
 

--- a/mythril/laser/plugin/plugins/coverage_metrics/coverage_data.py
+++ b/mythril/laser/plugin/plugins/coverage_metrics/coverage_data.py
@@ -1,7 +1,7 @@
 import json
 
-from mythril.support.support_utils import get_code_hash
 from mythril.laser.execution_info import ExecutionInfo
+from mythril.support.support_utils import get_code_hash
 
 
 class InstructionCoverageInfo(ExecutionInfo):

--- a/mythril/laser/plugin/plugins/coverage_metrics/metrics_plugin.py
+++ b/mythril/laser/plugin/plugins/coverage_metrics/metrics_plugin.py
@@ -1,15 +1,16 @@
-from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.plugin.interface import LaserPlugin
-from mythril.laser.plugin.builder import PluginBuilder
+import logging
+import time
+
 from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.svm import LaserEVM
+from mythril.laser.plugin.builder import PluginBuilder
+from mythril.laser.plugin.interface import LaserPlugin
+
+from .constants import BATCH_OF_STATES
 from .coverage_data import (
     CoverageTimeSeries,
     InstructionCoverageInfo,
 )
-from .constants import BATCH_OF_STATES
-
-import time
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/plugin/plugins/dependency_pruner.py
+++ b/mythril/laser/plugin/plugins/dependency_pruner.py
@@ -1,20 +1,20 @@
+import logging
+from typing import Dict, List, Set, cast
+
+from mythril.analysis import solver
+from mythril.exceptions import UnsatError
+from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.plugin.interface import LaserPlugin
+from mythril.laser.ethereum.transaction.transaction_models import (
+    ContractCreationTransaction,
+)
 from mythril.laser.plugin.builder import PluginBuilder
-from mythril.laser.plugin.signals import PluginSkipState
+from mythril.laser.plugin.interface import LaserPlugin
 from mythril.laser.plugin.plugins.plugin_annotations import (
     DependencyAnnotation,
     WSDependencyAnnotation,
 )
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.transaction.transaction_models import (
-    ContractCreationTransaction,
-)
-from mythril.exceptions import UnsatError
-from mythril.analysis import solver
-from typing import cast, List, Dict, Set
-import logging
-
+from mythril.laser.plugin.signals import PluginSkipState
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/plugin/plugins/instruction_profiler.py
+++ b/mythril/laser/plugin/plugins/instruction_profiler.py
@@ -1,11 +1,12 @@
+import logging
 from collections import namedtuple
 from datetime import datetime
 from typing import Dict, List, Tuple
+
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.svm import LaserEVM
 from mythril.laser.plugin.builder import PluginBuilder
 from mythril.laser.plugin.interface import LaserPlugin
-from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.ethereum.state.global_state import GlobalState
-import logging
 
 # Type annotations:
 #   start_time: datetime

--- a/mythril/laser/plugin/plugins/mutation_pruner.py
+++ b/mythril/laser/plugin/plugins/mutation_pruner.py
@@ -1,15 +1,15 @@
-from mythril.laser.plugin.signals import PluginSkipWorldState
-from mythril.laser.plugin.interface import LaserPlugin
-from mythril.laser.plugin.builder import PluginBuilder
-from mythril.laser.plugin.plugins.plugin_annotations import MutationAnnotation
+from mythril.analysis import solver
+from mythril.exceptions import UnsatError
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.smt import UGT, symbol_factory
 from mythril.laser.ethereum.transaction.transaction_models import (
     ContractCreationTransaction,
 )
-from mythril.analysis import solver
-from mythril.exceptions import UnsatError
+from mythril.laser.plugin.builder import PluginBuilder
+from mythril.laser.plugin.interface import LaserPlugin
+from mythril.laser.plugin.plugins.plugin_annotations import MutationAnnotation
+from mythril.laser.plugin.signals import PluginSkipWorldState
+from mythril.laser.smt import UGT, symbol_factory
 
 
 class MutationPrunerBuilder(PluginBuilder):

--- a/mythril/laser/plugin/plugins/plugin_annotations.py
+++ b/mythril/laser/plugin/plugins/plugin_annotations.py
@@ -1,11 +1,11 @@
-from mythril.laser.ethereum.state.annotation import (
-    StateAnnotation,
-    MergeableStateAnnotation,
-)
-
+import logging
 from copy import copy
 from typing import Dict, List, Set
-import logging
+
+from mythril.laser.ethereum.state.annotation import (
+    MergeableStateAnnotation,
+    StateAnnotation,
+)
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/plugin/plugins/state_merge/check_mergeability.py
+++ b/mythril/laser/plugin/plugins/state_merge/check_mergeability.py
@@ -1,8 +1,9 @@
 import logging
+
 from mythril.laser.ethereum.cfg import Node
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.state.account import Account
 from mythril.laser.ethereum.state.constraints import Constraints
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.smt import Not
 
 CONSTRAINT_DIFFERENCE_LIMIT = 15

--- a/mythril/laser/plugin/plugins/state_merge/merge_states.py
+++ b/mythril/laser/plugin/plugins/state_merge/merge_states.py
@@ -1,11 +1,12 @@
 import logging
+from typing import Tuple, cast
 
 from mythril.laser.ethereum.cfg import Node
-from typing import Tuple, cast
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.state.account import Account, Storage
 from mythril.laser.ethereum.state.constraints import Constraints
-from mythril.laser.smt import symbol_factory, Array, If, Or, And, Not, SMTBool as Bool
+from mythril.laser.ethereum.state.world_state import WorldState
+from mythril.laser.smt import And, Array, If, Not, Or, symbol_factory
+from mythril.laser.smt import SMTBool as Bool
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/plugin/plugins/state_merge/state_merge_plugin.py
+++ b/mythril/laser/plugin/plugins/state_merge/state_merge_plugin.py
@@ -1,12 +1,14 @@
+import logging
 from copy import copy
-from typing import Set, List
+from typing import List, Set
+
+from mythril.laser.ethereum.state.annotation import StateAnnotation
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.svm import LaserEVM
 from mythril.laser.plugin.interface import LaserPlugin
-from .merge_states import merge_states
+
 from .check_mergeability import check_ws_merge_condition
-from mythril.laser.ethereum.state.world_state import WorldState
-from mythril.laser.ethereum.state.annotation import StateAnnotation
-import logging
+from .merge_states import merge_states
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/plugin/plugins/summary/annotations.py
+++ b/mythril/laser/plugin/plugins/summary/annotations.py
@@ -1,10 +1,11 @@
-from mythril.laser.ethereum.state.annotation import StateAnnotation
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.smt import SMTBool as Bool, BaseArray
+from copy import deepcopy
 from typing import List, Tuple
 
-from copy import deepcopy
+from mythril.laser.ethereum.state.annotation import StateAnnotation
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.smt import BaseArray
+from mythril.laser.smt import SMTBool as Bool
 
 
 class SummaryTrackingAnnotation(StateAnnotation):

--- a/mythril/laser/plugin/plugins/summary/core.py
+++ b/mythril/laser/plugin/plugins/summary/core.py
@@ -1,41 +1,43 @@
-from .summary import SymbolicSummary, substitute_exprs
-from .annotations import SummaryTrackingAnnotation
+import logging
+from copy import copy, deepcopy
+from typing import List, Optional, Set, Tuple
+
+import z3
+
 from mythril.analysis.issue_annotation import IssueAnnotation
 from mythril.analysis.potential_issues import check_potential_issues
 from mythril.analysis.solver import get_transaction_sequence
 from mythril.exceptions import UnsatError
-
-from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.plugin.builder import PluginBuilder
-from mythril.laser.plugin.interface import LaserPlugin
-from mythril.laser.plugin.signals import PluginSkipState
-from mythril.laser.plugin.plugins.plugin_annotations import MutationAnnotation
-from mythril.laser.ethereum.transaction.transaction_models import (
-    ContractCreationTransaction,
-    BaseTransaction,
-)
-from mythril.support.support_utils import get_code_hash
 from mythril.laser.ethereum.function_managers import (
     keccak_function_manager,
 )
-
-from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.calldata import SymbolicCalldata
 from mythril.laser.ethereum.state.constraints import Constraints
 from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.calldata import SymbolicCalldata
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.svm import LaserEVM
+from mythril.laser.ethereum.transaction.transaction_models import (
+    BaseTransaction,
+    ContractCreationTransaction,
+)
+from mythril.laser.plugin.builder import PluginBuilder
+from mythril.laser.plugin.interface import LaserPlugin
+from mythril.laser.plugin.plugins.plugin_annotations import MutationAnnotation
+from mythril.laser.plugin.signals import PluginSkipState
 from mythril.laser.smt import (
     Array,
-    SMTBool as Bool,
+    Expression,
     Solver,
     symbol_factory,
-    Expression,
+)
+from mythril.laser.smt import (
+    SMTBool as Bool,
 )
 from mythril.support.support_args import args
-import z3
-from typing import Tuple, List, Optional, Set
-from copy import copy, deepcopy
+from mythril.support.support_utils import get_code_hash
 
-import logging
+from .annotations import SummaryTrackingAnnotation
+from .summary import SymbolicSummary, substitute_exprs
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/plugin/plugins/summary/summary.py
+++ b/mythril/laser/plugin/plugins/summary/summary.py
@@ -1,11 +1,12 @@
-from mythril.laser.smt import Array, Solver, symbol_factory
-from mythril.support.support_args import args
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.plugin.plugins.plugin_annotations import MutationAnnotation
+import logging
 from copy import deepcopy
 
-import logging
 import z3
+
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.plugin.plugins.plugin_annotations import MutationAnnotation
+from mythril.laser.smt import Array, Solver, symbol_factory
+from mythril.support.support_args import args
 
 log = logging.getLogger(__name__)
 

--- a/mythril/laser/plugin/plugins/trace.py
+++ b/mythril/laser/plugin/plugins/trace.py
@@ -1,8 +1,9 @@
-from mythril.laser.plugin.interface import LaserPlugin
-from mythril.laser.plugin.builder import PluginBuilder
+from typing import List, Tuple
+
 from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.svm import LaserEVM
-from typing import List, Tuple
+from mythril.laser.plugin.builder import PluginBuilder
+from mythril.laser.plugin.interface import LaserPlugin
 
 
 class TraceFinderBuilder(PluginBuilder):

--- a/mythril/laser/smt/__init__.py
+++ b/mythril/laser/smt/__init__.py
@@ -1,32 +1,32 @@
-from mythril.laser.smt.bitvec import BitVec
+from typing import Any, Generic, Optional, Set, TypeVar, Union
 
+import z3
+
+from mythril.laser.smt.array import Array, BaseArray, K
+from mythril.laser.smt.bitvec import BitVec
 from mythril.laser.smt.bitvec_helper import (
-    If,
-    UGT,
-    ULT,
-    ULE,
-    Concat,
-    Extract,
-    URem,
-    SRem,
-    UDiv,
     UGE,
-    Sum,
+    UGT,
+    ULE,
+    ULT,
     BVAddNoOverflow,
     BVMulNoOverflow,
     BVSubNoUnderflow,
+    Concat,
+    Extract,
+    If,
     LShR,
+    SRem,
+    Sum,
+    UDiv,
+    URem,
 )
-
+from mythril.laser.smt.bool import And, Not, Or, is_false, is_true
+from mythril.laser.smt.bool import Bool as SMTBool
 from mythril.laser.smt.expression import Expression, simplify
-from mythril.laser.smt.bool import Bool as SMTBool, is_true, is_false, Or, Not, And
-from mythril.laser.smt.array import K, Array, BaseArray
 from mythril.laser.smt.function import Function
-from mythril.laser.smt.solver import Solver, Optimize, SolverStatistics
 from mythril.laser.smt.model import Model
-from typing import Union, Any, Optional, Set, TypeVar, Generic
-import z3
-
+from mythril.laser.smt.solver import Optimize, Solver, SolverStatistics
 
 Annotations = Optional[Set[Any]]
 T = TypeVar("T", bound=Union[SMTBool, z3.BoolRef])

--- a/mythril/laser/smt/array.py
+++ b/mythril/laser/smt/array.py
@@ -6,6 +6,7 @@ default values over a certain range.
 """
 
 from typing import cast
+
 import z3
 
 from mythril.laser.smt.bitvec import BitVec

--- a/mythril/laser/smt/bitvec.py
+++ b/mythril/laser/smt/bitvec.py
@@ -1,7 +1,7 @@
 """This module provides classes for an SMT abstraction of bit vectors."""
 
-from operator import lshift, rshift, ne, eq
-from typing import Union, Set, cast, Any, Optional, Callable
+from operator import eq, lshift, ne, rshift
+from typing import Any, Callable, Optional, Set, Union, cast
 
 import z3
 

--- a/mythril/laser/smt/bitvec_helper.py
+++ b/mythril/laser/smt/bitvec_helper.py
@@ -1,9 +1,10 @@
-from typing import Union, overload, List, Set, cast, Any, Callable
+from typing import Any, Callable, List, Set, Union, cast, overload
+
 import z3
 
-from mythril.laser.smt.bool import Bool, Or
+from mythril.laser.smt.array import Array, BaseArray
 from mythril.laser.smt.bitvec import BitVec
-from mythril.laser.smt.array import BaseArray, Array
+from mythril.laser.smt.bool import Bool, Or
 
 Annotations = Set[Any]
 

--- a/mythril/laser/smt/bool.py
+++ b/mythril/laser/smt/bool.py
@@ -1,7 +1,7 @@
 """This module provides classes for an SMT abstraction of boolean
 expressions."""
 
-from typing import Union, cast, Set
+from typing import Set, Union, cast
 
 import z3
 

--- a/mythril/laser/smt/expression.py
+++ b/mythril/laser/smt/expression.py
@@ -1,8 +1,8 @@
 """This module contains the SMT abstraction for a basic symbol expression."""
 
-from typing import Optional, Set, Any, TypeVar, Generic, cast
-import z3
+from typing import Any, Generic, Optional, Set, TypeVar, cast
 
+import z3
 
 Annotations = Set[Any]
 T = TypeVar("T", bound=z3.ExprRef)

--- a/mythril/laser/smt/function.py
+++ b/mythril/laser/smt/function.py
@@ -1,4 +1,5 @@
-from typing import cast, List, Any, Set
+from typing import Any, List, Set, cast
+
 import z3
 
 from mythril.laser.smt.bitvec import BitVec

--- a/mythril/laser/smt/model.py
+++ b/mythril/laser/smt/model.py
@@ -1,6 +1,6 @@
-import z3
+from typing import List, Union
 
-from typing import Union, List
+import z3
 
 
 class Model:

--- a/mythril/laser/smt/solver/__init__.py
+++ b/mythril/laser/smt/solver/__init__.py
@@ -1,7 +1,7 @@
 import z3
 
-from mythril.laser.smt.solver.solver import Solver, Optimize, BaseSolver
 from mythril.laser.smt.solver.independence_solver import IndependenceSolver
+from mythril.laser.smt.solver.solver import BaseSolver, Optimize, Solver
 from mythril.laser.smt.solver.solver_statistics import SolverStatistics
 from mythril.support.support_args import args
 

--- a/mythril/laser/smt/solver/independence_solver.py
+++ b/mythril/laser/smt/solver/independence_solver.py
@@ -1,10 +1,10 @@
+from typing import Dict, List, Set, Tuple, cast
+
 import z3
 
-from mythril.laser.smt.model import Model
 from mythril.laser.smt.bool import Bool
+from mythril.laser.smt.model import Model
 from mythril.laser.smt.solver.solver_statistics import stat_smt_query
-
-from typing import Set, Tuple, Dict, List, cast
 
 
 def _get_expr_variables(expression: z3.ExprRef) -> List[z3.ExprRef]:

--- a/mythril/laser/smt/solver/solver.py
+++ b/mythril/laser/smt/solver/solver.py
@@ -3,12 +3,13 @@
 import logging
 import os
 import sys
-import z3
-from typing import Union, cast, TypeVar, Generic, List, Sequence
+from typing import Generic, List, Sequence, TypeVar, Union, cast
 
+import z3
+
+from mythril.laser.smt.bool import Bool
 from mythril.laser.smt.expression import Expression
 from mythril.laser.smt.model import Model
-from mythril.laser.smt.bool import Bool
 from mythril.laser.smt.solver.solver_statistics import stat_smt_query
 
 T = TypeVar("T", bound=Union[z3.Solver, z3.Optimize])

--- a/mythril/laser/smt/solver/solver_statistics.py
+++ b/mythril/laser/smt/solver/solver_statistics.py
@@ -1,8 +1,7 @@
 from time import time
+from typing import Callable
 
 from mythril.support.support_utils import Singleton
-
-from typing import Callable
 
 
 def stat_smt_query(func: Callable):

--- a/mythril/mythril/__init__.py
+++ b/mythril/mythril/__init__.py
@@ -1,3 +1,3 @@
-from .mythril_disassembler import MythrilDisassembler
 from .mythril_analyzer import MythrilAnalyzer
 from .mythril_config import MythrilConfig
+from .mythril_disassembler import MythrilDisassembler

--- a/mythril/mythril/mythril_analyzer.py
+++ b/mythril/mythril/mythril_analyzer.py
@@ -20,7 +20,7 @@ from mythril.support.source_support import Source
 from mythril.support.start_time import StartTime
 from mythril.support.support_args import args
 
-from . import MythrilDisassembler
+from .mythril_disassembler import MythrilDisassembler
 
 log = logging.getLogger(__name__)
 

--- a/mythril/mythril/mythril_analyzer.py
+++ b/mythril/mythril/mythril_analyzer.py
@@ -3,23 +3,24 @@
 
 import logging
 import traceback
-from typing import Optional, List
 from argparse import Namespace
+from typing import List, Optional
 
-from . import MythrilDisassembler
-from mythril.support.source_support import Source
-from mythril.support.loader import DynLoader
-from mythril.support.support_args import args
-from mythril.analysis.symbolic import SymExecWrapper
 from mythril.analysis.callgraph import generate_graph
-from mythril.analysis.traceexplore import get_serializable_statespace
+from mythril.analysis.report import Issue, Report
 from mythril.analysis.security import fire_lasers, retrieve_callback_issues
-from mythril.analysis.report import Report, Issue
+from mythril.analysis.symbolic import SymExecWrapper
+from mythril.analysis.traceexplore import get_serializable_statespace
 from mythril.ethereum.evmcontract import EVMContract
-from mythril.laser.smt import SolverStatistics
-from mythril.support.start_time import StartTime
 from mythril.exceptions import DetectorNotFoundError
 from mythril.laser.execution_info import ExecutionInfo
+from mythril.laser.smt import SolverStatistics
+from mythril.support.loader import DynLoader
+from mythril.support.source_support import Source
+from mythril.support.start_time import StartTime
+from mythril.support.support_args import args
+
+from . import MythrilDisassembler
 
 log = logging.getLogger(__name__)
 

--- a/mythril/mythril/mythril_config.py
+++ b/mythril/mythril/mythril_config.py
@@ -1,14 +1,13 @@
 import codecs
 import logging
 import os
-
+from configparser import ConfigParser
 from pathlib import Path
 from shutil import copyfile
-from configparser import ConfigParser
 from typing import Optional
 
-from mythril.exceptions import CriticalError
 from mythril.ethereum.interface.rpc.client import EthJsonRpc
+from mythril.exceptions import CriticalError
 from mythril.support.lock import LockFile
 
 log = logging.getLogger(__name__)

--- a/mythril/mythril/mythril_disassembler.py
+++ b/mythril/mythril/mythril_disassembler.py
@@ -1,31 +1,30 @@
 import json
 import logging
 import os
-from pathlib import Path
 import re
 import shutil
-import solc
 import subprocess
 import warnings
+from pathlib import Path
+from typing import List, Optional, Tuple
 
+import solc
 from eth_utils import int_to_big_endian
-from semantic_version import Version, NpmSpec
-from typing import List, Tuple, Optional
+from semantic_version import NpmSpec, Version
 
-from mythril.support.support_utils import sha3, zpad
 from mythril.ethereum import util
-from mythril.ethereum.interface.rpc.client import EthJsonRpc
-from mythril.exceptions import CriticalError, CompilerError, NoContractFoundError
-from mythril.support import signatures
-from mythril.support.support_utils import rzpad
-from mythril.support.support_args import args
 from mythril.ethereum.evmcontract import EVMContract
+from mythril.ethereum.interface.rpc.client import EthJsonRpc
 from mythril.ethereum.interface.rpc.exceptions import ConnectionError
+from mythril.exceptions import CompilerError, CriticalError, NoContractFoundError
 from mythril.solidity.soliditycontract import (
     SolidityContract,
     get_contracts_from_file,
     get_contracts_from_foundry,
 )
+from mythril.support import signatures
+from mythril.support.support_args import args
+from mythril.support.support_utils import rzpad, sha3, zpad
 
 
 def format_warning(message, category, filename, lineno, line=""):

--- a/mythril/plugin/__init__.py
+++ b/mythril/plugin/__init__.py
@@ -1,2 +1,2 @@
-from mythril.plugin.interface import MythrilPlugin, MythrilCLIPlugin
+from mythril.plugin.interface import MythrilCLIPlugin, MythrilPlugin
 from mythril.plugin.loader import MythrilPluginLoader

--- a/mythril/plugin/discovery.py
+++ b/mythril/plugin/discovery.py
@@ -4,10 +4,10 @@ try:
 except Exception:
     pkg_resources = None
     from importlib.metadata import entry_points
-from mythril.support.support_utils import Singleton
-from mythril.plugin.interface import MythrilPlugin
+from typing import Any, Dict, List, Optional
 
-from typing import List, Dict, Any, Optional
+from mythril.plugin.interface import MythrilPlugin
+from mythril.support.support_utils import Singleton
 
 
 class PluginDiscovery(object, metaclass=Singleton):

--- a/mythril/plugin/interface.py
+++ b/mythril/plugin/interface.py
@@ -1,4 +1,5 @@
 from abc import ABC
+
 from mythril.laser.plugin.builder import PluginBuilder as LaserPluginBuilder
 
 

--- a/mythril/plugin/loader.py
+++ b/mythril/plugin/loader.py
@@ -1,13 +1,12 @@
+import logging
+from typing import Dict
+
 from mythril.analysis.module import DetectionModule
-
-from mythril.plugin.interface import MythrilPlugin, MythrilLaserPlugin
-from mythril.plugin.discovery import PluginDiscovery
-from mythril.support.support_utils import Singleton
-
 from mythril.analysis.module.loader import ModuleLoader
 from mythril.laser.plugin.loader import LaserPluginLoader
-from typing import Dict
-import logging
+from mythril.plugin.discovery import PluginDiscovery
+from mythril.plugin.interface import MythrilLaserPlugin, MythrilPlugin
+from mythril.support.support_utils import Singleton
 
 log = logging.getLogger(__name__)
 

--- a/mythril/solidity/soliditycontract.py
+++ b/mythril/solidity/soliditycontract.py
@@ -1,8 +1,8 @@
 """This module contains representation classes for Solidity files, contracts
 and source mappings."""
 
-from typing import Dict, Set
 import logging
+from typing import Dict, Set
 
 import mythril.laser.ethereum.util as helper
 from mythril.ethereum.evmcontract import EVMContract

--- a/mythril/support/loader.py
+++ b/mythril/support/loader.py
@@ -1,12 +1,13 @@
 """This module contains the dynamic loader logic to get on-chain storage data
 and dependencies."""
 
-from mythril.disassembler.disassembly import Disassembly
+import functools
 import logging
 import re
-import functools
-from mythril.ethereum.interface.rpc.client import EthJsonRpc
 from typing import Optional
+
+from mythril.disassembler.disassembly import Disassembly
+from mythril.ethereum.interface.rpc.client import EthJsonRpc
 
 LRU_CACHE_SIZE = 4096
 

--- a/mythril/support/lock.py
+++ b/mythril/support/lock.py
@@ -1,6 +1,6 @@
+import errno
 import os
 import time
-import errno
 
 """
 credits: https://github.com/dmfrey/FileLock

--- a/mythril/support/model.py
+++ b/mythril/support/model.py
@@ -1,18 +1,18 @@
-from mythril.support.support_utils import ModelCache
-from mythril.support.support_args import args
-from mythril.laser.smt import Optimize, simplify, And
-from mythril.laser.ethereum.time_handler import time_handler
-from mythril.exceptions import UnsatError, SolverTimeOutException
-
 import logging
 import os
 import sys
-
 from functools import lru_cache
-from multiprocessing.pool import ThreadPool
 from multiprocessing import TimeoutError
+from multiprocessing.pool import ThreadPool
 from pathlib import Path
+
 from z3 import sat, unknown
+
+from mythril.exceptions import SolverTimeOutException, UnsatError
+from mythril.laser.ethereum.time_handler import time_handler
+from mythril.laser.smt import And, Optimize, simplify
+from mythril.support.support_args import args
+from mythril.support.support_utils import ModelCache
 
 log = logging.getLogger(__name__)
 

--- a/mythril/support/opcodes.py
+++ b/mythril/support/opcodes.py
@@ -1,6 +1,5 @@
 from typing import Dict
 
-
 Z_OPERATOR_TUPLE = (0, 1)
 UN_OPERATOR_TUPLE = (1, 1)
 BIN_OPERATOR_TUPLE = (2, 1)

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -6,7 +6,7 @@ import multiprocessing
 import os
 import sqlite3
 from collections import defaultdict
-from typing import List, DefaultDict, Dict
+from typing import DefaultDict, Dict, List
 
 from mythril.ethereum.util import get_solc_json
 

--- a/mythril/support/source_support.py
+++ b/mythril/support/source_support.py
@@ -1,5 +1,5 @@
-from mythril.solidity.soliditycontract import SolidityContract
 from mythril.ethereum.evmcontract import EVMContract
+from mythril.solidity.soliditycontract import SolidityContract
 
 
 class Source:

--- a/mythril/support/start_time.py
+++ b/mythril/support/start_time.py
@@ -1,4 +1,5 @@
 from time import time
+
 from mythril.support.support_utils import Singleton
 
 

--- a/mythril/support/support_args.py
+++ b/mythril/support/support_args.py
@@ -1,4 +1,5 @@
 from typing import List
+
 from mythril.support.support_utils import Singleton
 
 

--- a/mythril/support/support_utils.py
+++ b/mythril/support/support_utils.py
@@ -1,12 +1,13 @@
 """This module contains utility functions for the Mythril support package."""
 
+import logging
 from collections import OrderedDict
 from copy import deepcopy
-from eth_hash.auto import keccak
 from functools import lru_cache
 from typing import Dict
+
+from eth_hash.auto import keccak
 from z3 import is_true
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ target-version = "py37"
 [tool.ruff.lint]
 fixable = ["ALL"]
 # List of rules https://docs.astral.sh/ruff/rules/
-select = ["F"]
+select = ["F", "I"]
 
 [tool.ruff.lint.per-file-ignores]
 # Fine for __init__.py files:

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,12 @@ publish to pypi w/o having to convert Readme.md to RST:
     1) #> python setup.py sdist bdist_wheel
     2) #> twine upload dist/*   #<specify bdist_wheel version to upload>; #optional --repository <testpypi> or  --repository-url <testpypi-url>
 """
-from setuptools import setup, find_packages
-from setuptools.command.install import install as _install
-
-import sys
-import os
 import io
+import os
+import sys
 
+from setuptools import find_packages, setup
+from setuptools.command.install import install as _install
 
 # Package meta-data.
 NAME = "mythril"

--- a/tests/analysis/abi_decode_test.py
+++ b/tests/analysis/abi_decode_test.py
@@ -2,7 +2,6 @@ import pytest
 
 from mythril.analysis.report import Issue
 
-
 test_data = (
     (
         "0xa9059cbb000000000000000000000000010801010101010120020101020401010408040402",

--- a/tests/analysis/arbitrary_jump_test.py
+++ b/tests/analysis/arbitrary_jump_test.py
@@ -1,21 +1,21 @@
 import pytest
 
+from mythril.analysis.module.modules.arbitrary_jump import (
+    ArbitraryJump,
+    is_unique_jumpdest,
+)
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.smt import symbol_factory
-from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.call import SymbolicCalldata
 from mythril.laser.ethereum.state.account import Account
-from mythril.laser.ethereum.state.machine_state import MachineState
 from mythril.laser.ethereum.state.constraints import Constraints
+from mythril.laser.ethereum.state.environment import Environment
 from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
 from mythril.laser.ethereum.state.world_state import WorldState
+from mythril.laser.ethereum.time_handler import time_handler
 from mythril.laser.ethereum.transaction.symbolic import ACTORS
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
-from mythril.laser.ethereum.call import SymbolicCalldata
-from mythril.analysis.module.modules.arbitrary_jump import (
-    is_unique_jumpdest,
-    ArbitraryJump,
-)
-from mythril.laser.ethereum.time_handler import time_handler
+from mythril.laser.smt import symbol_factory
 
 
 def get_global_state(constraints):

--- a/tests/cli_tests/cli_opts_test.py
+++ b/tests/cli_tests/cli_opts_test.py
@@ -1,8 +1,9 @@
-from mythril.interfaces.cli import main
-import pytest
 import json
-
 import sys
+
+import pytest
+
+from mythril.interfaces.cli import main
 
 
 def test_version_opt(capsys):

--- a/tests/cmd_line_test.py
+++ b/tests/cmd_line_test.py
@@ -1,5 +1,6 @@
-from subprocess import check_output, CalledProcessError, STDOUT
-from tests import BaseTestCase, TESTDATA, PROJECT_DIR
+from subprocess import STDOUT, CalledProcessError, check_output
+
+from tests import PROJECT_DIR, TESTDATA, BaseTestCase
 
 MYTH = str(PROJECT_DIR / "myth")
 

--- a/tests/concolic/concolic_tests.py
+++ b/tests/concolic/concolic_tests.py
@@ -1,23 +1,22 @@
 import binascii
 import json
-import pytest
 import subprocess
-
 from copy import deepcopy
 from datetime import datetime
-from subprocess import check_output, CalledProcessError
-from tests import PROJECT_DIR, TESTDATA
+from subprocess import CalledProcessError, check_output
+
+import pytest
 
 from mythril.concolic import concrete_execution
 from mythril.concolic.find_trace import setup_concrete_initial_state
 from mythril.laser.ethereum import util
-
 from mythril.laser.ethereum.svm import LaserEVM
 from mythril.laser.ethereum.time_handler import time_handler
 from mythril.laser.ethereum.transaction.concolic import execute_transaction
 from mythril.laser.plugin.loader import LaserPluginLoader
-from mythril.laser.smt import symbol_factory
 from mythril.laser.plugin.plugins import TraceFinderBuilder
+from mythril.laser.smt import symbol_factory
+from tests import PROJECT_DIR, TESTDATA
 
 MYTH = str(PROJECT_DIR / "myth")
 

--- a/tests/disassembler/asm_test.py
+++ b/tests/disassembler/asm_test.py
@@ -1,10 +1,11 @@
+import pytest
+
 from mythril.disassembler.asm import (
     disassemble,
     find_op_code_sequence,
-    is_sequence_match,
     get_opcode_from_name,
+    is_sequence_match,
 )
-import pytest
 
 valid_names = [("PUSH1", 0x60), ("STOP", 0x0), ("RETURN", 0xF3)]
 

--- a/tests/disassembler/disassembly_test.py
+++ b/tests/disassembler/disassembly_test.py
@@ -1,4 +1,4 @@
-from mythril.disassembler.disassembly import get_function_info, SignatureDB
+from mythril.disassembler.disassembly import SignatureDB, get_function_info
 
 instruction_list = [
     {"opcode": "PUSH4", "argument": "0x10203040"},

--- a/tests/disassembler_test.py
+++ b/tests/disassembler_test.py
@@ -1,11 +1,12 @@
+import os
+
 from mythril.disassembler.disassembly import Disassembly
 from tests import (
-    BaseTestCase,
     TESTDATA_INPUTS,
-    TESTDATA_OUTPUTS_EXPECTED,
     TESTDATA_OUTPUTS_CURRENT,
+    TESTDATA_OUTPUTS_EXPECTED,
+    BaseTestCase,
 )
-import os
 
 
 class DisassemblerTestCase(BaseTestCase):

--- a/tests/features_test.py
+++ b/tests/features_test.py
@@ -1,5 +1,7 @@
-import pytest
 from pathlib import Path
+
+import pytest
+
 from mythril.mythril import MythrilDisassembler
 from mythril.solidity.features import SolidityFeatureExtractor
 from mythril.solidity.soliditycontract import SolidityContract

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -2,11 +2,12 @@
 This test only checks whether dumping is successful, not whether the dumped state space makes sense
 """
 
-from mythril.mythril import MythrilAnalyzer, MythrilDisassembler
+from types import SimpleNamespace
+
 from mythril.ethereum import util
+from mythril.mythril import MythrilAnalyzer, MythrilDisassembler
 from mythril.solidity.soliditycontract import EVMContract
 from tests import TESTDATA_INPUTS
-from types import SimpleNamespace
 
 
 def test_generate_graph():

--- a/tests/instructions/basefee_test.py
+++ b/tests/instructions/basefee_test.py
@@ -1,9 +1,9 @@
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
 from mythril.laser.smt import symbol_factory
 

--- a/tests/instructions/codecopy_test.py
+++ b/tests/instructions/codecopy_test.py
@@ -1,9 +1,9 @@
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
 
 

--- a/tests/instructions/create2_test.py
+++ b/tests/instructions/create2_test.py
@@ -1,17 +1,18 @@
 import pytest
+
 from mythril.disassembler.disassembly import Disassembly
+from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.calldata import ConcreteCalldata
 from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.machine_state import MachineState
 from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
 from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.time_handler import time_handler
-from mythril.laser.ethereum.instructions import Instruction
 from mythril.laser.ethereum.transaction.transaction_models import (
     MessageCallTransaction,
     TransactionStartSignal,
 )
 from mythril.laser.smt import symbol_factory
-from mythril.laser.ethereum.state.calldata import ConcreteCalldata
 from mythril.support.support_utils import get_code_hash
 
 last_state = None

--- a/tests/instructions/create_test.py
+++ b/tests/instructions/create_test.py
@@ -1,17 +1,17 @@
 import pytest
 
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.calldata import ConcreteCalldata
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
+from mythril.laser.ethereum.time_handler import time_handler
 from mythril.laser.ethereum.transaction.transaction_models import (
     MessageCallTransaction,
     TransactionStartSignal,
 )
-from mythril.laser.ethereum.state.calldata import ConcreteCalldata
-from mythril.laser.ethereum.time_handler import time_handler
 
 last_state = None
 created_contract_account = None

--- a/tests/instructions/extcodecopy_test.py
+++ b/tests/instructions/extcodecopy_test.py
@@ -1,11 +1,11 @@
-from mythril.laser.smt import symbol_factory
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
+from mythril.laser.smt import symbol_factory
 
 
 def test_extcodecopy():

--- a/tests/instructions/extcodehash_test.py
+++ b/tests/instructions/extcodehash_test.py
@@ -1,14 +1,12 @@
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
-
-from mythril.support.support_utils import get_code_hash
-
 from mythril.laser.smt import symbol_factory
+from mythril.support.support_utils import get_code_hash
 
 # Arrange
 world_state = WorldState()

--- a/tests/instructions/push_test.py
+++ b/tests/instructions/push_test.py
@@ -1,13 +1,13 @@
 import pytest
 
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.world_state import WorldState
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
-from mythril.laser.smt import symbol_factory, simplify
+from mythril.laser.smt import simplify, symbol_factory
 
 
 def get_state(input):

--- a/tests/instructions/sar_test.py
+++ b/tests/instructions/sar_test.py
@@ -1,13 +1,13 @@
 import pytest
 
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.world_state import WorldState
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
 from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
-from mythril.laser.smt import symbol_factory, simplify
+from mythril.laser.smt import simplify, symbol_factory
 
 
 def get_state():

--- a/tests/instructions/shl_test.py
+++ b/tests/instructions/shl_test.py
@@ -1,13 +1,13 @@
 import pytest
 
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
-from mythril.laser.smt import symbol_factory, simplify
+from mythril.laser.smt import simplify, symbol_factory
 
 
 def get_state():

--- a/tests/instructions/shr_test.py
+++ b/tests/instructions/shr_test.py
@@ -1,13 +1,13 @@
 import pytest
 
 from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
-from mythril.laser.smt import symbol_factory, simplify, LShR
+from mythril.laser.smt import LShR, simplify, symbol_factory
 
 
 def get_state():

--- a/tests/instructions/static_call_test.py
+++ b/tests/instructions/static_call_test.py
@@ -1,19 +1,19 @@
-import pytest
 from unittest.mock import patch
 
-from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.smt import symbol_factory
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.account import Account
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.world_state import WorldState
-from mythril.laser.ethereum.instructions import Instruction
-from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
-from mythril.laser.ethereum.call import SymbolicCalldata
-from mythril.laser.ethereum.transaction import TransactionStartSignal
+import pytest
 
+from mythril.disassembler.disassembly import Disassembly
+from mythril.laser.ethereum.call import SymbolicCalldata
 from mythril.laser.ethereum.evm_exceptions import WriteProtection
+from mythril.laser.ethereum.instructions import Instruction
+from mythril.laser.ethereum.state.account import Account
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
+from mythril.laser.ethereum.transaction import TransactionStartSignal
+from mythril.laser.ethereum.transaction.transaction_models import MessageCallTransaction
+from mythril.laser.smt import symbol_factory
 
 
 def get_global_state():

--- a/tests/integration_tests/analysis_tests.py
+++ b/tests/integration_tests/analysis_tests.py
@@ -1,7 +1,8 @@
-import pytest
 import json
 
+import pytest
 from utils import output_of
+
 from tests import PROJECT_DIR, TESTDATA
 
 MYTH = str(PROJECT_DIR / "myth")

--- a/tests/integration_tests/coverage_metrics_test.py
+++ b/tests/integration_tests/coverage_metrics_test.py
@@ -1,7 +1,7 @@
 import pytest
+from utils import output_of
 
 from tests import PROJECT_DIR, TESTDATA
-from utils import output_of
 
 MYTH = str(PROJECT_DIR / "myth")
 

--- a/tests/integration_tests/old_version_test.py
+++ b/tests/integration_tests/old_version_test.py
@@ -1,8 +1,9 @@
-import pytest
 import json
 
-from tests import PROJECT_DIR, TESTDATA
+import pytest
 from utils import output_of
+
+from tests import PROJECT_DIR, TESTDATA
 
 MYTH = str(PROJECT_DIR / "myth")
 test_data = (

--- a/tests/integration_tests/safe_functions_test.py
+++ b/tests/integration_tests/safe_functions_test.py
@@ -1,8 +1,7 @@
 import pytest
-
 from utils import output_of
-from tests import PROJECT_DIR, TESTDATA
 
+from tests import PROJECT_DIR, TESTDATA
 
 MYTH = str(PROJECT_DIR / "myth")
 test_data = (

--- a/tests/integration_tests/solc_settings_test.py
+++ b/tests/integration_tests/solc_settings_test.py
@@ -1,4 +1,5 @@
-from subprocess import check_output, STDOUT
+from subprocess import STDOUT, check_output
+
 from tests import PROJECT_DIR, TESTDATA
 
 MYTH = str(PROJECT_DIR / "myth")

--- a/tests/integration_tests/src_mapping_test.py
+++ b/tests/integration_tests/src_mapping_test.py
@@ -1,6 +1,8 @@
 from subprocess import STDOUT
-from tests import PROJECT_DIR, TESTDATA
+
 from utils import output_of
+
+from tests import PROJECT_DIR, TESTDATA
 
 MYTH = str(PROJECT_DIR / "myth")
 

--- a/tests/integration_tests/state_merge_tests.py
+++ b/tests/integration_tests/state_merge_tests.py
@@ -1,9 +1,9 @@
-import pytest
 import os
 import subprocess
 
-from tests import PROJECT_DIR, TESTDATA
+import pytest
 
+from tests import PROJECT_DIR, TESTDATA
 
 MYTH = str(PROJECT_DIR / "myth")
 

--- a/tests/integration_tests/summary_test.py
+++ b/tests/integration_tests/summary_test.py
@@ -1,8 +1,9 @@
-import pytest
 import json
 
-from tests import PROJECT_DIR, TESTDATA
+import pytest
 from utils import output_of
+
+from tests import PROJECT_DIR, TESTDATA
 
 MYTH = str(PROJECT_DIR / "myth")
 

--- a/tests/integration_tests/transient_storage_test.py
+++ b/tests/integration_tests/transient_storage_test.py
@@ -1,7 +1,7 @@
 import pytest
+from utils import output_of
 
 from tests import PROJECT_DIR, TESTDATA
-from utils import output_of
 
 MYTH = str(PROJECT_DIR / "myth")
 

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -1,4 +1,4 @@
-from subprocess import check_output, CalledProcessError
+from subprocess import CalledProcessError, check_output
 
 
 def output_of(command, stderr=None):

--- a/tests/integration_tests/version_test.py
+++ b/tests/integration_tests/version_test.py
@@ -1,7 +1,7 @@
 import pytest
+from utils import output_of
 
 from tests import PROJECT_DIR, TESTDATA
-from utils import output_of
 
 MYTH = str(PROJECT_DIR / "myth")
 test_data = (

--- a/tests/laser/Precompiles/blake2_test.py
+++ b/tests/laser/Precompiles/blake2_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from mythril.laser.ethereum.natives import blake2b_fcompress
 
 

--- a/tests/laser/Precompiles/ec_add_test.py
+++ b/tests/laser/Precompiles/ec_add_test.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
+
 from eth_utils import decode_hex
-from mythril.laser.ethereum.natives import ec_add
 from py_ecc.optimized_bn128 import FQ
+
+from mythril.laser.ethereum.natives import ec_add
 
 VECTOR_A = decode_hex(
     "0000000000000000000000000000000000000000000000000000000000000001"

--- a/tests/laser/Precompiles/ecrecover_test.py
+++ b/tests/laser/Precompiles/ecrecover_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mythril.laser.ethereum.natives import ecrecover, NativeContractException
+from mythril.laser.ethereum.natives import NativeContractException, ecrecover
 from mythril.laser.smt import symbol_factory
 
 msg = b"\x6b\x8d\x2c\x81\xb1\x1b\x2d\x69\x95\x28\xdd\xe4\x88\xdb\xdf\x2f\x94\x29\x3d\x0d\x33\xc3\x2e\x34\x7f\x25\x5f\xa4\xa6\xc1\xf0\xa9"

--- a/tests/laser/Precompiles/elliptic_curves_test.py
+++ b/tests/laser/Precompiles/elliptic_curves_test.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
-from mythril.laser.ethereum.natives import ec_pair
+
 from py_ecc.optimized_bn128 import FQ
+
+from mythril.laser.ethereum.natives import ec_pair
 
 
 def test_ec_pair_192_check():

--- a/tests/laser/Precompiles/elliptic_mul_test.py
+++ b/tests/laser/Precompiles/elliptic_mul_test.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
+
 from eth_utils import decode_hex
-from mythril.laser.ethereum.natives import ec_mul
 from py_ecc.optimized_bn128 import FQ
+
+from mythril.laser.ethereum.natives import ec_mul
 
 VECTOR_A = decode_hex(
     "0000000000000000000000000000000000000000000000000000000000000001"

--- a/tests/laser/Precompiles/mod_exp_test.py
+++ b/tests/laser/Precompiles/mod_exp_test.py
@@ -1,7 +1,7 @@
 import pytest
-from eth_utils import decode_hex, big_endian_to_int
-from mythril.laser.ethereum.natives import mod_exp
+from eth_utils import big_endian_to_int, decode_hex
 
+from mythril.laser.ethereum.natives import mod_exp
 
 EIP198_VECTOR_A = decode_hex(
     "0000000000000000000000000000000000000000000000000000000000000001"

--- a/tests/laser/Precompiles/ripemd_test.py
+++ b/tests/laser/Precompiles/ripemd_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mythril.laser.ethereum.natives import ripemd160, NativeContractException
+from mythril.laser.ethereum.natives import NativeContractException, ripemd160
 from mythril.laser.smt import symbol_factory
 
 

--- a/tests/laser/Precompiles/sha256_test.py
+++ b/tests/laser/Precompiles/sha256_test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mythril.laser.ethereum.natives import sha256, NativeContractException
+from mythril.laser.ethereum.natives import NativeContractException, sha256
 from mythril.laser.smt import symbol_factory
 
 

--- a/tests/laser/evm_testsuite/evm_test.py
+++ b/tests/laser/evm_testsuite/evm_test.py
@@ -1,17 +1,18 @@
-from mythril.laser.ethereum.svm import LaserEVM
+import binascii
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from mythril.disassembler.disassembly import Disassembly
 from mythril.laser.ethereum.state.account import Account
 from mythril.laser.ethereum.state.world_state import WorldState
+from mythril.laser.ethereum.svm import LaserEVM
 from mythril.laser.ethereum.time_handler import time_handler
-from mythril.disassembler.disassembly import Disassembly
 from mythril.laser.ethereum.transaction.concolic import execute_message_call
 from mythril.laser.smt import Expression, symbol_factory
 from mythril.support.support_args import args
-from datetime import datetime
-
-import binascii
-import json
-from pathlib import Path
-import pytest
 
 evm_test_dir = Path(__file__).parent / "VMTests"
 

--- a/tests/laser/keccak_tests.py
+++ b/tests/laser/keccak_tests.py
@@ -1,7 +1,8 @@
-from mythril.laser.smt import Solver, symbol_factory
-from mythril.laser.ethereum.function_managers import keccak_function_manager
-import z3
 import pytest
+import z3
+
+from mythril.laser.ethereum.function_managers import keccak_function_manager
+from mythril.laser.smt import Solver, symbol_factory
 
 
 @pytest.mark.parametrize(

--- a/tests/laser/smt/independece_solver_test.py
+++ b/tests/laser/smt/independece_solver_test.py
@@ -1,12 +1,12 @@
+import z3
+
+from mythril.laser.smt import symbol_factory
 from mythril.laser.smt.solver.independence_solver import (
-    _get_expr_variables,
     DependenceBucket,
     DependenceMap,
     IndependenceSolver,
+    _get_expr_variables,
 )
-from mythril.laser.smt import symbol_factory
-
-import z3
 
 
 def test_get_expr_variables():

--- a/tests/laser/smt/model_test.py
+++ b/tests/laser/smt/model_test.py
@@ -1,5 +1,6 @@
-from mythril.laser.smt import Solver, symbol_factory
 import z3
+
+from mythril.laser.smt import Solver, symbol_factory
 
 
 def test_decls():

--- a/tests/laser/state/calldata_test.py
+++ b/tests/laser/state/calldata_test.py
@@ -1,7 +1,8 @@
 import pytest
+from z3 import unsat
+
 from mythril.laser.ethereum.state.calldata import ConcreteCalldata, SymbolicCalldata
 from mythril.laser.smt import Solver, symbol_factory
-from z3 import unsat
 
 uninitialized_test_data = [
     ([]),  # Empty concrete calldata

--- a/tests/laser/state/mstack_test.py
+++ b/tests/laser/state/mstack_test.py
@@ -1,11 +1,10 @@
 import pytest
 
-from mythril.laser.ethereum.state.machine_state import MachineStack
-
 from mythril.laser.ethereum.evm_exceptions import (
     StackOverflowException,
     StackUnderflowException,
 )
+from mythril.laser.ethereum.state.machine_state import MachineStack
 from tests import BaseTestCase
 
 

--- a/tests/laser/state/mstate_test.py
+++ b/tests/laser/state/mstate_test.py
@@ -1,10 +1,10 @@
 import pytest
 from eth._utils.numeric import ceil32
-from mythril.laser.smt import simplify, symbol_factory, Concat, Extract
 
-from mythril.laser.ethereum.state.machine_state import MachineState
 from mythril.laser.ethereum.evm_exceptions import StackUnderflowException
+from mythril.laser.ethereum.state.machine_state import MachineState
 from mythril.laser.ethereum.state.memory import Memory
+from mythril.laser.smt import Concat, Extract, simplify, symbol_factory
 
 memory_extension_test_data = [(0, 0, 10), (0, 30, 10), (100, 22, 8)]
 

--- a/tests/laser/state/storage_test.py
+++ b/tests/laser/state/storage_test.py
@@ -1,7 +1,7 @@
 import pytest
-from mythril.laser.smt import symbol_factory
+
 from mythril.laser.ethereum.state.account import Storage
-from mythril.laser.smt import Expression
+from mythril.laser.smt import Expression, symbol_factory
 from mythril.support.support_args import args
 
 BVV = symbol_factory.BitVecVal

--- a/tests/laser/strategy/beam_test.py
+++ b/tests/laser/strategy/beam_test.py
@@ -1,13 +1,14 @@
 import pytest
+
+from mythril.analysis.potential_issues import PotentialIssuesAnnotation
+from mythril.disassembler.disassembly import Disassembly
+from mythril.laser.ethereum.state.environment import Environment
+from mythril.laser.ethereum.state.global_state import GlobalState
+from mythril.laser.ethereum.state.machine_state import MachineState
+from mythril.laser.ethereum.state.world_state import WorldState
 from mythril.laser.ethereum.strategy.beam import (
     BeamSearch,
 )
-from mythril.disassembler.disassembly import Disassembly
-from mythril.laser.ethereum.state.environment import Environment
-from mythril.laser.ethereum.state.machine_state import MachineState
-from mythril.laser.ethereum.state.global_state import GlobalState
-from mythril.laser.ethereum.state.world_state import WorldState
-from mythril.analysis.potential_issues import PotentialIssuesAnnotation
 
 world_state = WorldState()
 account = world_state.create_account(balance=10, address=101)

--- a/tests/laser/strategy/loop_bound_test.py
+++ b/tests/laser/strategy/loop_bound_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from mythril.laser.ethereum.strategy.extensions.bounded_loops import (
     BoundedLoopsStrategy,
 )

--- a/tests/laser/transaction/create_transaction_test.py
+++ b/tests/laser/transaction/create_transaction_test.py
@@ -1,13 +1,14 @@
-from mythril.mythril import MythrilDisassembler
-from mythril.laser.ethereum.transaction import execute_contract_creation
-from mythril.ethereum import util
-import mythril.laser.ethereum.svm as svm
-from mythril.disassembler.disassembly import Disassembly
 from datetime import datetime
-from mythril.solidity.soliditycontract import SolidityContract
+
+import mythril.laser.ethereum.svm as svm
 import tests
 from mythril.analysis.security import fire_lasers
 from mythril.analysis.symbolic import SymExecWrapper
+from mythril.disassembler.disassembly import Disassembly
+from mythril.ethereum import util
+from mythril.laser.ethereum.transaction import execute_contract_creation
+from mythril.mythril import MythrilDisassembler
+from mythril.solidity.soliditycontract import SolidityContract
 
 solc_binary = MythrilDisassembler._init_solc_binary("v0.5.0")
 

--- a/tests/laser/transaction/symbolic_test.py
+++ b/tests/laser/transaction/symbolic_test.py
@@ -1,18 +1,18 @@
-from mythril.laser.ethereum.transaction.symbolic import (
-    execute_message_call,
-    execute_contract_creation,
-)
-from mythril.laser.ethereum.transaction import (
-    MessageCallTransaction,
-    ContractCreationTransaction,
-)
-from mythril.laser.ethereum.svm import LaserEVM
-from mythril.laser.ethereum.state.account import Account
-from mythril.laser.ethereum.state.world_state import WorldState
-from mythril.laser.smt import symbol_factory
-
 import unittest.mock as mock
 from unittest.mock import MagicMock
+
+from mythril.laser.ethereum.state.account import Account
+from mythril.laser.ethereum.state.world_state import WorldState
+from mythril.laser.ethereum.svm import LaserEVM
+from mythril.laser.ethereum.transaction import (
+    ContractCreationTransaction,
+    MessageCallTransaction,
+)
+from mythril.laser.ethereum.transaction.symbolic import (
+    execute_contract_creation,
+    execute_message_call,
+)
+from mythril.laser.smt import symbol_factory
 
 
 def _is_message_call(_, transaction, transaction_sequences):

--- a/tests/laser/tx_prioritisation_test.py
+++ b/tests/laser/tx_prioritisation_test.py
@@ -1,7 +1,9 @@
-import pytest
+from unittest.mock import Mock, mock_open, patch
+
 import numpy as np
+import pytest
+
 from mythril.laser.ethereum.tx_prioritiser import RfTxPrioritiser
-from unittest.mock import Mock, patch, mock_open
 
 
 def mock_predict_proba(X):

--- a/tests/mythril/mythril_analyzer_test.py
+++ b/tests/mythril/mythril_analyzer_test.py
@@ -1,8 +1,9 @@
 from pathlib import Path
-from mythril.mythril import MythrilDisassembler, MythrilAnalyzer
-from mythril.analysis.report import Issue
-from unittest.mock import patch, PropertyMock
 from types import SimpleNamespace
+from unittest.mock import PropertyMock, patch
+
+from mythril.analysis.report import Issue
+from mythril.mythril import MythrilAnalyzer, MythrilDisassembler
 
 
 @patch("mythril.analysis.report.Issue.add_code_info", return_value=None)

--- a/tests/mythril/mythril_config_test.py
+++ b/tests/mythril/mythril_config_test.py
@@ -1,10 +1,10 @@
-import pytest
-
 from configparser import ConfigParser
 from pathlib import Path
 
-from mythril.mythril import MythrilConfig
+import pytest
+
 from mythril.exceptions import CriticalError
+from mythril.mythril import MythrilConfig
 
 
 def test_config_path_dynloading():

--- a/tests/plugin/loader_test.py
+++ b/tests/plugin/loader_test.py
@@ -1,7 +1,7 @@
-from mythril.plugin import MythrilPluginLoader, MythrilPlugin
-from mythril.plugin.loader import UnsupportedPluginType
-
 import pytest
+
+from mythril.plugin import MythrilPlugin, MythrilPluginLoader
+from mythril.plugin.loader import UnsupportedPluginType
 
 
 def test_typecheck_load():

--- a/tests/rpc_test.py
+++ b/tests/rpc_test.py
@@ -1,6 +1,5 @@
-from tests import BaseTestCase
-
 from mythril.ethereum.interface.rpc.client import EthJsonRpc
+from tests import BaseTestCase
 
 
 class RpcTest(BaseTestCase):

--- a/tests/statespace_test.py
+++ b/tests/statespace_test.py
@@ -1,8 +1,9 @@
-from mythril.mythril import MythrilAnalyzer, MythrilDisassembler
+from types import SimpleNamespace
+
 from mythril.ethereum import util
+from mythril.mythril import MythrilAnalyzer, MythrilDisassembler
 from mythril.solidity.soliditycontract import EVMContract
 from tests import TESTDATA_INPUTS
-from types import SimpleNamespace
 
 
 def test_statespace_dump():

--- a/tests/testdata/compile.py
+++ b/tests/testdata/compile.py
@@ -1,5 +1,6 @@
 # compile test contracts
 from pathlib import Path
+
 from mythril.solidity.soliditycontract import SolidityContract
 
 # Recompiles all the to be tested contracts

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -2,7 +2,6 @@ import pytest
 
 from mythril.ethereum.util import extract_version
 
-
 test_data = (
     ("pragma solidity 0.5.0\n", ["0.5.0"]),
     ("pragma solidity =0.5.0\n", ["0.5.0"]),


### PR DESCRIPTION
This enables [isort](https://pycqa.github.io/isort/) via ruff/pre-commit and applies it fully automatically (no manual changes), which results in sorting of the imports (no additions or removals).

While this looks like a cosmetic thing, the intention is different:
* Sorting in to sections (stdlib, 3rd party libs, own code..): Ensures that any 3rd party / own code does not overwrite imports from stdlib and the sections also help to see what comes from where.
* Alphabetical ordering within sections: helps to find things within sections, when reading the imports.

This now also runs the black hook after ruff, as reordering imports can result in some work for black.