### PR TITLE
Add pre-commit hook definition + test

### DIFF
--- a/.github/workflows/pre-commit-hooks-test.yml
+++ b/.github/workflows/pre-commit-hooks-test.yml
@@ -1,0 +1,32 @@
+name: pre-commit
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+    tags:
+      - '*'
+  pull_request:
+    paths:
+      - .github/workflows/pre-commit-hooks-test.yml
+      - .pre-commit-hooks.yaml
+      - tests/pre-commit-hooks/*
+      - requirements.txt
+      - setup.py
+
+jobs:
+  hooks-test:
+    runs-on: ubuntu-latest
+    name: test hooks
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install pre-commit
+        run: |
+          python -m pip install pre-commit
+      - name: Test hooks
+        run: |
+          ./tests/pre-commit-hooks/test.sh

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: mythril
+  name: Mythril
+  description: Analyze EVM bytecode with Mythril
+  entry: myth
+  args:
+    - analyze
+  language: python
+  types: ["solidity"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Install from Pypi (Python 3.7-3.10):
 $ pip3 install mythril
 ```
 
+Use it via pre-commit hook (replace `$GIT_TAG` with real tag):
+
+```YAML
+- repo: https://github.com/Consensys/mythril
+  rev: $GIT_TAG
+  hooks:
+    - id: mythril
+```
+
 See the [docs](https://mythril-classic.readthedocs.io/en/master/installation.html) for more detailed instructions. 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Use it via pre-commit hook (replace `$GIT_TAG` with real tag):
     - id: mythril
 ```
 
+Additionally set `args: [disassemble]` or  and `args: [read-storage]` to use a different command than `analyse`.
+
 See the [docs](https://mythril-classic.readthedocs.io/en/master/installation.html) for more detailed instructions. 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Use it via pre-commit hook (replace `$GIT_TAG` with real tag):
     - id: mythril
 ```
 
-Additionally set `args: [disassemble]` or  and `args: [read-storage]` to use a different command than `analyze`.
+Additionally, set `args: [disassemble]` or `args: [read-storage]` to use a different command than `analyze`.
 
 See the [docs](https://mythril-classic.readthedocs.io/en/master/installation.html) for more detailed instructions. 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Use it via pre-commit hook (replace `$GIT_TAG` with real tag):
     - id: mythril
 ```
 
-Additionally set `args: [disassemble]` or  and `args: [read-storage]` to use a different command than `analyse`.
+Additionally set `args: [disassemble]` or  and `args: [read-storage]` to use a different command than `analyze`.
 
 See the [docs](https://mythril-classic.readthedocs.io/en/master/installation.html) for more detailed instructions. 
 

--- a/tests/pre-commit-hooks/Counter.sol
+++ b/tests/pre-commit-hooks/Counter.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.26;
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}

--- a/tests/pre-commit-hooks/test.sh
+++ b/tests/pre-commit-hooks/test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -o errtrace -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# Create temp working directory for mock repo
+MOCK_REPO=$(mktemp -d)
+if [[ ! "$MOCK_REPO" || ! -d "$MOCK_REPO" ]]; then
+    echo "Could not create temp dir"
+    exit 1
+fi
+function cleanup {
+    echo "Deleting temp working directory $MOCK_REPO"
+    rm -rf "$MOCK_REPO"
+}
+trap cleanup EXIT
+
+# Filling the mock repo
+pushd "$MOCK_REPO" >/dev/null || exit 1
+git init --initial-branch=master
+git config user.email "test@example.com"
+git config user.name "pre-commit test"
+cp "$SCRIPT_DIR/Counter.sol" .
+git add .
+git commit -m "Initial commit"
+
+# Run pre-commit inside the mock repo while referencing the mythril directory,
+# where the .pre-commit-hooks.yaml is located.
+pre-commit try-repo "$SCRIPT_DIR/../.." mythril --verbose --color=always --all-files


### PR DESCRIPTION
This adds a `.pre-commit-hooks.yaml` (+ doc + test), which allows other projects to run Mythril via pre-commit.

[pre-commit](https://pre-commit.com/) became pretty popular as framework to combine linters / code-formatters via [hooks](https://pre-commit.com/hooks.html) across different languages. It can be enabled as actual git hook or just used by running `pre-commit run -a`. pre-commit does its own dependency management (+cashing) and installs each hook into its own isolated folder/env.

pre-commit installs a hook by cloning the `repo`, checking out the specified git `rev` (=tag, branch, commit hash), parsing the .pre-commit-hooks.yaml and installing the hook (install method depending on the hook type).

Tested also via my Mythril fork, see https://github.com/dbast/sol-press/pull/17

Requires a new tagged release after the PR merge to be able to reference a tag that contains the hook definition.