### PR TITLE
Manual version pinning updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ asn1crypto>=0.22.0
 configparser>=3.5.0
 py_ecc>=5.0.0
 eth-abi>=5.1.0
-eth-hash<0.4.0,>=0.3.1
+eth-hash>=0.3.1,<0.8.0
 eth-utils>=2.0.0
-hexbytes<0.3.0
+hexbytes<1.3.0
 jinja2>=2.9
-MarkupSafe<2.1.0
+MarkupSafe<2.2.0
 mypy-extensions==1.0.0
 numpy
 persistent>=4.2.0
@@ -18,9 +18,9 @@ py-flags
 py-evm==0.10.1b1
 py-solc-x<2.0.0
 py-solc
-pyparsing<3,>=2.0.2
+pyparsing>=2.0.2,<4
 requests
-rlp<4,>=3
+rlp>=3,<5
 semantic_version
 z3-solver<=4.13.0.0,>=4.8.8.0
 matplotlib


### PR DESCRIPTION
This manually does the dependency version pinning updates that are done + individually tested by dependabot in https://github.com/Consensys/mythril/pull/1872, https://github.com/Consensys/mythril/pull/1873, https://github.com/Consensys/mythril/pull/1875, https://github.com/Consensys/mythril/pull/1876 but cannot be merged due to cla-assistant approval being missing. The PR also additionally updates the MarkupSafe version pinning, which dependabot  did not propose yet due to the default dependabot PR rate limit of 5 open PRs.


`pip list --outdated`:

* before


```
Package    Version Latest Type
---------- ------- ------ -----
eth-bloom  1.0.4   3.0.1  wheel
eth-hash   0.3.3   0.7.0  wheel
eth-utils  2.3.1   5.0.0  wheel
hexbytes   0.2.3   1.2.1  wheel
MarkupSafe 2.0.1   2.1.5  wheel
py-solc-x  1.1.1   2.0.3  wheel
pyparsing  2.4.7   3.1.2  wheel
rlp        3.0.0   4.0.1  wheel
```

* after:

```
Package    Version Latest Type
---------- ------- ------ -----
py-solc-x  1.1.1   2.0.3  wheel
```

The py-solc-x version pinning update has to be handled separately due to currently failures in https://github.com/Consensys/mythril/pull/1874