### PR TITLE
Bugfix function signature misreport

### DIFF
--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -56,7 +56,7 @@ class Disassembly(object):
                 if function_hash in ignore_false_funcs:
                     continue
             elif isinstance(argument, tuple):
-                function_hash = int.from_bytes(bytes(argument), 'big')
+                function_hash = int.from_bytes(bytes(argument), "big")
                 if function_hash in ignore_false_funcs:
                     continue
 

--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Tuple
 from mythril.disassembler import asm
 from mythril.ethereum import util
 from mythril.support.signatures import SignatureDB
+from mythril.support.support_args import args
 
 
 class Disassembly(object):
@@ -44,9 +45,18 @@ class Disassembly(object):
         )
 
         for index in jump_table_indices:
+            ignore_false_funcs = args.ignore_false_funcs
+            # ignore the default func hashes if ignore_false_funcs is None
+            if ignore_false_funcs is None \
+                and self.instruction_list[index]["argument"] in ['0x01', '0x02', '0x03', '0x04']:
+                continue
             function_hash, jump_target, function_name = get_function_info(
                 index, self.instruction_list, signatures
             )
+            # ignore the function if it is in the ignore_false_funcs list
+            if ignore_false_funcs and function_hash in ignore_false_funcs:
+                continue
+            
             self.func_hashes.append(function_hash)
             if jump_target is not None and function_name is not None:
                 self.function_name_to_address[function_name] = jump_target

--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -1,12 +1,12 @@
 """This module contains the class used to represent disassembly code."""
 
+from ast import literal_eval
 from typing import Dict, List, Tuple
 
 from mythril.disassembler import asm
 from mythril.ethereum import util
 from mythril.support.signatures import SignatureDB
 from mythril.support.support_args import args
-from ast import literal_eval
 
 
 class Disassembly(object):
@@ -52,13 +52,13 @@ class Disassembly(object):
             # ignore the default func hashes if ignore_false_funcs is None
             argument = self.instruction_list[index]["argument"]
             function_hash = literal_eval(argument)
-            
+
             if function_hash in ignore_false_funcs:
                 continue
             function_hash, jump_target, function_name = get_function_info(
                 index, self.instruction_list, signatures
             )
-            
+
             self.func_hashes.append(function_hash)
             if jump_target is not None and function_name is not None:
                 self.function_name_to_address[function_name] = jump_target

--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -51,10 +51,15 @@ class Disassembly(object):
         for index in jump_table_indices:
             # ignore the default func hashes if ignore_false_funcs is None
             argument = self.instruction_list[index]["argument"]
-            function_hash = literal_eval(argument)
+            if isinstance(argument, str):
+                function_hash = literal_eval(argument)
+                if function_hash in ignore_false_funcs:
+                    continue
+            elif isinstance(argument, tuple):
+                function_hash = int.from_bytes(bytes(argument), 'big')
+                if function_hash in ignore_false_funcs:
+                    continue
 
-            if function_hash in ignore_false_funcs:
-                continue
             function_hash, jump_target, function_name = get_function_info(
                 index, self.instruction_list, signatures
             )

--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -6,6 +6,7 @@ from mythril.disassembler import asm
 from mythril.ethereum import util
 from mythril.support.signatures import SignatureDB
 from mythril.support.support_args import args
+from ast import literal_eval
 
 
 class Disassembly(object):
@@ -43,19 +44,20 @@ class Disassembly(object):
         jump_table_indices = asm.find_op_code_sequence(
             [("PUSH1", "PUSH2", "PUSH3", "PUSH4"), ("EQ",)], self.instruction_list
         )
+        ignore_false_funcs = args.ignore_false_funcs
+        if ignore_false_funcs is None:
+            ignore_false_funcs = [1, 2, 3, 4]
 
         for index in jump_table_indices:
-            ignore_false_funcs = args.ignore_false_funcs
             # ignore the default func hashes if ignore_false_funcs is None
-            if ignore_false_funcs is None \
-                and self.instruction_list[index]["argument"] in ['0x01', '0x02', '0x03', '0x04']:
+            argument = self.instruction_list[index]["argument"]
+            function_hash = literal_eval(argument)
+            
+            if function_hash in ignore_false_funcs:
                 continue
             function_hash, jump_target, function_name = get_function_info(
                 index, self.instruction_list, signatures
             )
-            # ignore the function if it is in the ignore_false_funcs list
-            if ignore_false_funcs and function_hash in ignore_false_funcs:
-                continue
             
             self.func_hashes.append(function_hash)
             if jump_target is not None and function_name is not None:

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -669,7 +669,7 @@ def validate_args(args: Namespace):
             )
         if len(args.transaction_sequences) != args.transaction_count:
             args.transaction_count = len(args.transaction_sequences)
-            
+
     if getattr(args, "ignore_false_funcs", None):
         try:
             args.ignore_false_funcs = literal_eval(str(args.ignore_false_funcs))
@@ -680,7 +680,6 @@ def validate_args(args: Namespace):
                 "[func1, func2, ...]. The default ignore false functions are "
                 "[0x00000001, 0x00000002, 0x00000003, 0x00000004]",
             )
-            
 
 
 def set_config(args: Namespace):

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -471,6 +471,14 @@ def add_analysis_args(options):
         "with func_hash1 and func_hash2, and the second tx is constrained with func_hash2 and func_hash3. Use -1 as a proxy for fallback() function and -2 for receive() function.",
     )
     options.add_argument(
+        "--ignore-false-funcs",
+        type=str,
+        nargs='+',
+        default=None,
+        help="List of function signatures that should be ignored as false positives."
+        "usage: --ignore-false-funcs [func1, func2, ...]",
+    )
+    options.add_argument(
         "--beam-search",
         type=int,
         default=None,
@@ -661,6 +669,18 @@ def validate_args(args: Namespace):
             )
         if len(args.transaction_sequences) != args.transaction_count:
             args.transaction_count = len(args.transaction_sequences)
+            
+    if getattr(args, "ignore_false_funcs", None):
+        try:
+            args.ignore_false_funcs = literal_eval(str(args.ignore_false_funcs))
+        except ValueError:
+            exit_with_error(
+                args.outform,
+                "The ignore false functions are in incorrect format, It should be "
+                "[func1, func2, ...]. The default ignore false functions are "
+                "[0x00000001, 0x00000002, 0x00000003, 0x00000004]",
+            )
+            
 
 
 def set_config(args: Namespace):

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -27,6 +27,7 @@ from mythril.exceptions import (
 from mythril.laser.ethereum.transaction.symbolic import ACTORS
 from mythril.mythril import MythrilAnalyzer, MythrilConfig, MythrilDisassembler
 from mythril.plugin.loader import MythrilPluginLoader
+from mythril.support.support_args import args as support_args
 
 # Initialise core Mythril Component
 _ = MythrilPluginLoader()
@@ -473,7 +474,6 @@ def add_analysis_args(options):
     options.add_argument(
         "--ignore-false-funcs",
         type=str,
-        nargs='+',
         default=None,
         help="List of function signatures that should be ignored as false positives."
         "usage: --ignore-false-funcs [func1, func2, ...]",
@@ -974,6 +974,7 @@ def parse_args_and_execute(parser: ArgumentParser, args: Namespace) -> None:
         solc_json = getattr(args, "solc_json", None)
         solv = getattr(args, "solv", None)
         solc_args = getattr(args, "solc_args", None)
+        support_args.ignore_false_funcs = getattr(args, "ignore_false_funcs", None)
         disassembler = MythrilDisassembler(
             eth=config.eth,
             solc_version=solv,

--- a/mythril/support/support_args.py
+++ b/mythril/support/support_args.py
@@ -18,6 +18,7 @@ class Args(object, metaclass=Singleton):
         self.disable_iprof = False
         self.solver_log = None
         self.transaction_sequences: List[List[str]] = None
+        self.ignore_false_funcs: List[str] = None
         self.use_integer_module = True
         self.use_issue_annotations = False
         self.solc_args = None

--- a/tests/integration_tests/ignore_false_funcs_test.py
+++ b/tests/integration_tests/ignore_false_funcs_test.py
@@ -1,0 +1,16 @@
+import pytest
+from utils import output_of
+
+from tests import PROJECT_DIR, TESTDATA
+
+MYTH = str(PROJECT_DIR / "myth")
+
+test_data = [
+    (f"{TESTDATA}/input_contracts/base_case.sol", "0x83197ef0"),
+]
+
+@pytest.mark.parametrize("file_name, ignore_func", test_data)
+def test_ignore_false_funcs(file_name, ignore_func):
+    print(file_name)
+    output = output_of(f"{MYTH} a {file_name} --ignore-false-funcs [{ignore_func}]")
+    assert "Function name: destroy()" not in output

--- a/tests/integration_tests/ignore_false_funcs_test.py
+++ b/tests/integration_tests/ignore_false_funcs_test.py
@@ -9,6 +9,7 @@ test_data = [
     (f"{TESTDATA}/input_contracts/base_case.sol", "0x83197ef0"),
 ]
 
+
 @pytest.mark.parametrize("file_name, ignore_func", test_data)
 def test_ignore_false_funcs(file_name, ignore_func):
     print(file_name)


### PR DESCRIPTION
## Description
* Implement a filter to exclude common false positive signatures, such as account_info_rotate_tine(uint256), as well as 0x00000001.
* Add `--ignore-false-funcs` argument to ignore false positive function signatures

This PR introduces a new command-line argument `--ignore-false-funcs` in cli.py. This argument accepts a list of function signatures to be ignored as false positives.

Usage Example:
```
python myth a -a 0x0aaeb2f7209b5796a3f323dcdf9cc4a7981ec8bf -t 1 --bin-runtime --unconstrained-storage --infura-id <infura-id> --transaction-sequences [[0x022c0d9f]] --ignore-false-funcs [0x00000001]
```