### PR TITLE
Fix ValueError when parsing empty hex offset in disassembly

### DIFF
--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -1,3 +1,4 @@
+#mythril/disassembler/disassembly.py
 """This module contains the class used to represent disassembly code."""
 
 from typing import Dict, List, Tuple
@@ -106,7 +107,10 @@ def get_function_info(
         offset = instruction_list[index + 2]["argument"]
         if isinstance(offset, tuple):
             offset = bytes(offset).hex()
-        entry_point = int(offset, 16)
+        if offset and len(offset) > 2:
+            entry_point = int(offset, 16)
+        else:
+            entry_point = 0
     except (KeyError, IndexError):
         return function_hash, None, None
 


### PR DESCRIPTION
Fixes #1912

Handle edge case where offset is '0x' without digits when analyzing contracts with non-256-bit integers compiled with --via-ir --optimize. Add validation before hex-to-int conversion to prevent crash.